### PR TITLE
Make public the spec API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Specs as an importable API library under `pkg`.
+- Prometheus SLO spec.
+- Cli for Prometheus generation.
+- Generic Multi window multi burn alert generation.
+- Prometheus SLI error recording rules.
+- Prometheus SLO Metadata recording rules.
+- Prometheus Multi window multi burn alert rules.
+- Improve 30d SLI error recording rule.
+- Disable recording rules generation using flags.
+- Disable alert rules generation using flags.
+
 [unreleased]: https://github.com/slok/sloth/compare/v0.1.0...HEAD
 [v0.1.0]: https://github.com/slok/sloth/releases/tag/v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/slok/sloth
 go 1.16
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-playground/validator/v10 v10.5.0
 	github.com/prometheus/common v0.21.0
 	github.com/prometheus/prometheus v1.8.2-0.20210331101223-3cafc58827d1 // v2.26.0 (Avoid semver incompatibilies with commit)

--- a/go.sum
+++ b/go.sum
@@ -177,7 +177,6 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/pkg/prometheus/api/v1/v1.go
+++ b/pkg/prometheus/api/v1/v1.go
@@ -1,0 +1,37 @@
+package v1
+
+const Version = "prometheus/v1"
+
+type Spec struct {
+	Version string            `yaml:"version"`
+	Service string            `yaml:"service"`
+	Labels  map[string]string `yaml:"labels,omitempty"`
+	SLOs    []SLO             `yaml:"slos"`
+}
+
+type SLO struct {
+	Name      string            `yaml:"name"`
+	Objective float64           `yaml:"objective"`
+	Labels    map[string]string `yaml:"labels,omitempty"`
+	SLI       SLI               `yaml:"sli"`
+	Alerting  Alerting          `yaml:"alerting,omitempty"`
+}
+
+type SLI struct {
+	ErrorQuery string `yaml:"error_query"`
+	TotalQuery string `yaml:"total_query"`
+}
+
+type Alerting struct {
+	Name        string            `yaml:"name" validate:"required"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	PageAlert   *Alert            `yaml:"page_alert,omitempty"`
+	TicketAlert *Alert            `yaml:"ticket_alert,omitempty"`
+}
+
+type Alert struct {
+	Disable     bool              `yaml:"disable,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}


### PR DESCRIPTION
Also removed JSON support by changing `github.com/ghodss/yaml` in favor of the already being used dependency `gopkg.in/yaml.v2`.