### PR TITLE
deploy/kubernetes: move to PodMonitor

### DIFF
--- a/deploy/kubernetes/sloth.yaml
+++ b/deploy/kubernetes/sloth.yaml
@@ -67,25 +67,8 @@ spec:
               protocol: TCP
 
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: sloth
-  namespace: monitoring
-  labels:
-    app: sloth
-spec:
-  selector:
-    app: sloth
-  type: ClusterIP
-  ports:
-    - name: metrics
-      port: 8081
-      protocol: TCP
-
----
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: sloth
   namespace: monitoring
@@ -96,5 +79,5 @@ spec:
   selector:
     matchLabels:
       app: sloth
-  endpoints:
+  podMetricsEndpoints:
     - port: metrics


### PR DESCRIPTION
Since sloth doesn't use its port for anything else than exposing metrics, there is no need to create a Service object and use ServiceMonitor when the same functionality can be accomplished with PodMonitor.

OT: Great project! :tada: 