### PR TITLE
Use dynamic plugin loader service that can be reloaded instead of a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- (Internal) SLI Plugins are retrieved from a repository service instead of getting them from a `map`.
+
 ## [v0.4.0] - 2021-06-24
 
 ### Added

--- a/cmd/sloth/commands/generate.go
+++ b/cmd/sloth/commands/generate.go
@@ -61,14 +61,14 @@ func (g generateCommand) Run(ctx context.Context, config RootConfig) error {
 	}
 
 	// Load plugins
-	plugins, err := loadPlugins(ctx, config.Logger, g.sliPluginsPaths)
+	pluginRepo, err := createPluginLoader(ctx, config.Logger, g.sliPluginsPaths)
 	if err != nil {
-		return fmt.Errorf("could not load plugins: %w", err)
+		return err
 	}
 
 	// Create Spec loaders.
-	promYAMLLoader := prometheus.NewYAMLSpecLoader(plugins)
-	kubeYAMLLoader := k8sprometheus.NewYAMLSpecLoader(plugins)
+	promYAMLLoader := prometheus.NewYAMLSpecLoader(pluginRepo)
+	kubeYAMLLoader := k8sprometheus.NewYAMLSpecLoader(pluginRepo)
 
 	// Prepare store output.
 	var out io.Writer = config.Stdout

--- a/cmd/sloth/commands/helpers.go
+++ b/cmd/sloth/commands/helpers.go
@@ -38,27 +38,17 @@ func splitYAML(data []byte) []string {
 	return nonEmptyData
 }
 
-func loadPlugins(ctx context.Context, logger log.Logger, paths []string) (map[string]prometheus.SLIPlugin, error) {
-	plugins := map[string]prometheus.SLIPlugin{}
-	if len(paths) > 0 {
-		config := prometheus.FileSLIPluginRepoConfig{
-			Paths:  paths,
-			Logger: logger,
-		}
-		sliPluginRepo, err := prometheus.NewFileSLIPluginRepo(config)
-		if err != nil {
-			return nil, fmt.Errorf("could not create file SLI plugin repository: %w", err)
-		}
-
-		ps, err := sliPluginRepo.ListSLIPlugins(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not load plugins: %w", err)
-		}
-		plugins = ps
-		config.Logger.WithValues(log.Kv{"plugins": len(plugins)}).Infof("SLI plugins loaded")
+func createPluginLoader(ctx context.Context, logger log.Logger, paths []string) (*prometheus.FileSLIPluginRepo, error) {
+	config := prometheus.FileSLIPluginRepoConfig{
+		Paths:  paths,
+		Logger: logger,
+	}
+	sliPluginRepo, err := prometheus.NewFileSLIPluginRepo(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not create file SLI plugin repository: %w", err)
 	}
 
-	return plugins, nil
+	return sliPluginRepo, nil
 }
 
 func discoverSLOManifests(logger log.Logger, exclude, include *regexp.Regexp, path string) ([]string, error) {

--- a/cmd/sloth/commands/validate.go
+++ b/cmd/sloth/commands/validate.go
@@ -63,15 +63,15 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 		return fmt.Errorf("0 slo specs have been discovered")
 	}
 
-	// Load plugins
-	plugins, err := loadPlugins(ctx, config.Logger, v.sliPluginsPaths)
+	// Load plugins.
+	pluginRepo, err := createPluginLoader(ctx, config.Logger, v.sliPluginsPaths)
 	if err != nil {
-		return fmt.Errorf("could not load plugins: %w", err)
+		return err
 	}
 
 	// Create Spec loaders.
-	promYAMLLoader := prometheus.NewYAMLSpecLoader(plugins)
-	kubeYAMLLoader := k8sprometheus.NewYAMLSpecLoader(plugins)
+	promYAMLLoader := prometheus.NewYAMLSpecLoader(pluginRepo)
+	kubeYAMLLoader := k8sprometheus.NewYAMLSpecLoader(pluginRepo)
 
 	// For every file load the data and start the validation process:
 	validations := []*fileValidation{}

--- a/internal/k8sprometheus/spec_test.go
+++ b/internal/k8sprometheus/spec_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/slok/sloth/internal/prometheus"
 )
 
+type testMemPluginsRepo map[string]prometheus.SLIPlugin
+
+func (t testMemPluginsRepo) GetSLIPlugin(ctx context.Context, id string) (*prometheus.SLIPlugin, error) {
+	p, ok := t[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown plugin")
+	}
+	return &p, nil
+}
+
 func TestYAMLoadSpec(t *testing.T) {
 	tests := map[string]struct {
 		specYaml string
@@ -344,7 +354,7 @@ spec:
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			loader := k8sprometheus.NewYAMLSpecLoader(test.plugins)
+			loader := k8sprometheus.NewYAMLSpecLoader(testMemPluginsRepo(test.plugins))
 			gotModel, err := loader.LoadSpec(context.TODO(), []byte(test.specYaml))
 
 			if test.expErr {

--- a/internal/prometheus/sli_plugin.go
+++ b/internal/prometheus/sli_plugin.go
@@ -166,8 +166,9 @@ func (f *FileSLIPluginRepo) Reload(ctx context.Context) error {
 
 	// Set loaded plugins.
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.plugins = plugins
+	f.mu.Unlock()
+
 	f.logger.WithValues(log.Kv{"plugins": len(plugins)}).Infof("SLI plugins loaded")
 
 	return nil

--- a/internal/prometheus/sli_plugin_test.go
+++ b/internal/prometheus/sli_plugin_test.go
@@ -124,19 +124,17 @@ func SLIPlugin(ctx context.Context, meta, labels, options map[string]string) (st
 				Paths:       []string{"./"},
 			}
 			repo, err := prometheus.NewFileSLIPluginRepo(config)
-			require.NoError(err)
-
-			plugins, err := repo.ListSLIPlugins(context.TODO())
 			if test.expErrLoad {
 				assert.Error(err)
 				return
 			}
 			assert.NoError(err)
 
-			// Execute pluginand check.
-			assert.Len(plugins, 1)
-			plugin, ok := plugins[test.expPluginID]
-			assert.True(ok)
+			// Get plugin.
+			plugin, err := repo.GetSLIPlugin(context.TODO(), test.expPluginID)
+			require.NoError(err)
+
+			// Check.
 			assert.Equal(test.expPluginID, plugin.ID)
 
 			gotSLIQuery, err := plugin.Func(context.TODO(), test.meta, test.labels, test.options)

--- a/internal/prometheus/spec_test.go
+++ b/internal/prometheus/spec_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/slok/sloth/internal/prometheus"
 )
 
+type testMemPluginsRepo map[string]prometheus.SLIPlugin
+
+func (t testMemPluginsRepo) GetSLIPlugin(ctx context.Context, id string) (*prometheus.SLIPlugin, error) {
+	p, ok := t[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown plugin")
+	}
+	return &p, nil
+}
+
 func TestYAMLoadSpec(t *testing.T) {
 	tests := map[string]struct {
 		specYaml string
@@ -275,7 +285,7 @@ slos:
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			loader := prometheus.NewYAMLSpecLoader(test.plugins)
+			loader := prometheus.NewYAMLSpecLoader(testMemPluginsRepo(test.plugins))
 			gotModel, err := loader.LoadSpec(context.TODO(), []byte(test.specYaml))
 
 			if test.expErr {


### PR DESCRIPTION
This change sets a cleaner way of obtaining SLI plugins and gives us the ability to make a hotreload of plugins in the future.