### PR TITLE
Add hot-reload support for SLI plugins (with webhook and SIGHUP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- Hot-reload on SLI plugin file loader, triggered by HTTP webhook.
+- Hot-reload SLI plugins file loader
+- Trigger hot-reload by HTTP webhook.
+- Trigger hot-reload by SIGHUP OS signal.
 - Added `hot-reload-addr` flag with the hot reload http server address.
 - Added `hot-reload-path` flag with the hot reload http server webhookpath webhook.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Hot-reload on SLI plugin file loader, triggered by HTTP webhook.
+- Added `hot-reload-addr` flag with the hot reload http server address.
+- Added `hot-reload-path` flag with the hot reload http server webhookpath webhook.
+
 ### Changed
 
 - (Internal) SLI Plugins are retrieved from a repository service instead of getting them from a `map`.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/common v0.29.0
 	github.com/prometheus/prometheus v1.8.2-0.20210512173212-24c9b61221f7 // v2.27.0 (Avoid semver incompatibilies with commit).
 	github.com/sirupsen/logrus v1.8.1
+	github.com/slok/reload v0.0.0-20210626084015-0a501536aad9
 	github.com/spotahome/kooper/v2 v2.0.0-rc.2
 	github.com/stretchr/testify v1.7.0
 	github.com/traefik/yaegi v0.9.19

--- a/go.sum
+++ b/go.sum
@@ -774,6 +774,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slok/reload v0.0.0-20210626084015-0a501536aad9 h1:P07Wuq6/IA9FPXP8NUtg1RBsKmN8QfY9RRBOWtrA+wM=
+github.com/slok/reload v0.0.0-20210626084015-0a501536aad9/go.mod h1:XhUnP5A4uzivshdF7yG7BckrIxjVHJ4BMHSXqA2Xess=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
SLI plugins will work as always, except now we can load again all of them from the specified file paths when we want by:

- Making a POST request on the hot-reload HTTP address port and path (by default on `0.0.0.0:8082/-/reload`). 
- Sending a SIGHUP to the Sloth process.

This can be interesting using it alongside with [git-sync](https://github.com/kubernetes/git-sync) sidecar.

Examples:

- HTTP: `curl -XPOST http://127.0.0.1:8082/-/reload`.
- Signal: `kill -HUP 567040`.