### PR TITLE
Infer spec type on validate and generate commands, instead of using bruteforce by loading all of them as a chain of fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Generate and validate commands now infer the spec type instead of bruteforce loading every spec type.
+
 ## [v0.5.0] - 2021-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ slos:
         error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
         total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
     alerting:
-      name: MyServiceHighErrorRate
+      name: "MyServiceHighErrorRate"
       labels:
         category: "availability"
       annotations:
@@ -78,8 +78,8 @@ slos:
         summary: "High error rate on 'myservice' requests responses"
       page_alert:
         labels:
-          severity: pageteam
-          routing_key: myteam
+          severity: "pageteam"
+          routing_key: "myteam"
       ticket_alert:
         labels:
           severity: "slack"
@@ -175,7 +175,7 @@ INFO[0000] SLO alert rules generated                     rules=2 slo=home-wifi-r
 
 Sloth supports [OpenSLO v1alpha](https://github.com/OpenSLO/OpenSLO) spec, however we need to take into account that it has some restrictions:
 
-- OpenSLO timewindow restricted to 30 day.
+- OpenSLO timewindow restricted to 30 days.
 - Only Objective ratio metrics are supported.
 - Only Prometheus and PromQL query types are supported.
 - Configuration fields not required by Sloth will be ignored.
@@ -185,7 +185,7 @@ Regarding Sloth fatures, [OpenSLO] spec doesn't support all of the sloth feature
 - No Prometheus labels support.
 - No alerting support.
 - No SLI plugins support.
-- No Kubernetes support (at least until oficial OpenSLO CRDs are released).
+- No Kubernetes support (at least until official OpenSLO CRDs are released).
 
 Check [examples](#examples) to see some OpenSLO example specs.
 

--- a/internal/k8sprometheus/spec.go
+++ b/internal/k8sprometheus/spec.go
@@ -3,6 +3,7 @@ package k8sprometheus
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +30,15 @@ func NewYAMLSpecLoader(pluginsRepo SLIPluginRepo) YAMLSpecLoader {
 		pluginsRepo: pluginsRepo,
 		decoder:     scheme.Codecs.UniversalDeserializer(),
 	}
+}
+
+var (
+	specTypeV1RegexKind       = regexp.MustCompile(`(?m)^kind: +['"]?PrometheusServiceLevel['"]? *$`)
+	specTypeV1RegexAPIVersion = regexp.MustCompile(`(?m)^apiVersion: +['"]?sloth.slok.dev\/v1['"]? *$`)
+)
+
+func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+	return specTypeV1RegexKind.Match(data) && specTypeV1RegexAPIVersion.Match(data)
 }
 
 func (y YAMLSpecLoader) LoadSpec(ctx context.Context, data []byte) (*SLOGroup, error) {

--- a/internal/k8sprometheus/spec_test.go
+++ b/internal/k8sprometheus/spec_test.go
@@ -365,3 +365,79 @@ spec:
 		})
 	}
 }
+
+func TestYAMLIsSpecType(t *testing.T) {
+	tests := map[string]struct {
+		specYaml string
+		exp      bool
+	}{
+		"An empty spec type shouldn't match": {
+			specYaml: ``,
+			exp:      false,
+		},
+
+		"An wrong spec type shouldn't match": {
+			specYaml: `{`,
+			exp:      false,
+		},
+
+		"An incorrect spec api version type shouldn't match": {
+			specYaml: `
+apiVersion: sloth.slok.dev/v2
+kind: PrometheusServiceLevel
+`,
+			exp: false,
+		},
+
+		"An incorrect spec kind type shouldn't match": {
+			specYaml: `
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusService
+`,
+			exp: false,
+		},
+
+		"An correct spec type should match": {
+			specYaml: `
+apiVersion: "sloth.slok.dev/v1"
+kind: "PrometheusServiceLevel"
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (no quotes)": {
+			specYaml: `
+apiVersion: sloth.slok.dev/v1
+kind: PrometheusServiceLevel
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (single quotes)": {
+			specYaml: `
+apiVersion: 'sloth.slok.dev/v1'
+kind: 'PrometheusServiceLevel'
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (multiple spaces)": {
+			specYaml: `
+apiVersion:       sloth.slok.dev/v1           
+kind:               PrometheusServiceLevel      
+`,
+			exp: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			loader := k8sprometheus.NewYAMLSpecLoader(testMemPluginsRepo(map[string]prometheus.SLIPlugin{}))
+			got := loader.IsSpecType(context.TODO(), []byte(test.specYaml))
+
+			assert.Equal(test.exp, got)
+		})
+	}
+}

--- a/internal/openslo/spec.go
+++ b/internal/openslo/spec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -18,6 +19,15 @@ type yamlSpecLoader bool
 
 // YAMLSpecLoader knows how to load YAML specs and converts them to a model.
 const YAMLSpecLoader = yamlSpecLoader(false)
+
+var (
+	specTypeV1AlphaRegexKind       = regexp.MustCompile(`(?m)^kind: +['"]?SLO['"]? *$`)
+	specTypeV1AlphaRegexAPIVersion = regexp.MustCompile(`(?m)^apiVersion: +['"]?openslo\/v1alpha['"]? *$`)
+)
+
+func (y yamlSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+	return specTypeV1AlphaRegexKind.Match(data) && specTypeV1AlphaRegexAPIVersion.Match(data)
+}
 
 func (y yamlSpecLoader) LoadSpec(ctx context.Context, data []byte) (*prometheus.SLOGroup, error) {
 	if len(data) == 0 {

--- a/internal/openslo/spec_test.go
+++ b/internal/openslo/spec_test.go
@@ -316,3 +316,78 @@ spec:
 		})
 	}
 }
+
+func TestYAMLIsSpecType(t *testing.T) {
+	tests := map[string]struct {
+		specYaml string
+		exp      bool
+	}{
+		"An empty spec type shouldn't match": {
+			specYaml: ``,
+			exp:      false,
+		},
+
+		"An wrong spec type shouldn't match": {
+			specYaml: `{`,
+			exp:      false,
+		},
+
+		"An incorrect spec api version type shouldn't match": {
+			specYaml: `
+apiVersion: openslo/v1
+kind: SLO
+`,
+			exp: false,
+		},
+
+		"An incorrect spec kind type shouldn't match": {
+			specYaml: `
+apiVersion: openslo/v1alpha
+kind: service
+`,
+			exp: false,
+		},
+
+		"An correct spec type should match": {
+			specYaml: `
+apiVersion: "openslo/v1alpha"
+kind: "SLO"
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (no quotes)": {
+			specYaml: `
+apiVersion: openslo/v1alpha
+kind: SLO
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (single quotes)": {
+			specYaml: `
+apiVersion: 'openslo/v1alpha'
+kind: 'SLO'
+`,
+			exp: true,
+		},
+
+		"An correct spec type should match (multiple spaces)": {
+			specYaml: `
+apiVersion:          openslo/v1alpha     
+kind:              SLO     
+`,
+			exp: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			got := openslo.YAMLSpecLoader.IsSpecType(context.TODO(), []byte(test.specYaml))
+
+			assert.Equal(test.exp, got)
+		})
+	}
+}

--- a/internal/prometheus/spec.go
+++ b/internal/prometheus/spec.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -25,6 +26,12 @@ func NewYAMLSpecLoader(pluginsRepo SLIPluginRepo) YAMLSpecLoader {
 	return YAMLSpecLoader{
 		pluginsRepo: pluginsRepo,
 	}
+}
+
+var specTypeV1Regex = regexp.MustCompile(`(?m)^version: +['"]?prometheus\/v1['"]? *$`)
+
+func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+	return specTypeV1Regex.Match(data)
 }
 
 func (y YAMLSpecLoader) LoadSpec(ctx context.Context, data []byte) (*SLOGroup, error) {

--- a/internal/prometheus/spec_test.go
+++ b/internal/prometheus/spec_test.go
@@ -296,3 +296,56 @@ slos:
 		})
 	}
 }
+
+func TestYAMLIsSpecType(t *testing.T) {
+	tests := map[string]struct {
+		specYaml string
+		exp      bool
+	}{
+		"An empty spec type shouldn't match": {
+			specYaml: ``,
+			exp:      false,
+		},
+
+		"An wrong spec type shouldn't match": {
+			specYaml: `{`,
+			exp:      false,
+		},
+
+		"An incorrect spec version type shouldn't match": {
+			specYaml: `version: "prometheus/v2"`,
+			exp:      false,
+		},
+
+		"An correct spec type should match": {
+			specYaml: `version: "prometheus/v1"`,
+			exp:      true,
+		},
+
+		"An correct spec type should match (no quotes)": {
+			specYaml: `version: prometheus/v1`,
+			exp:      true,
+		},
+
+		"An correct spec type should match (single quotes)": {
+			specYaml: `version: 'prometheus/v1'`,
+			exp:      true,
+		},
+
+		"An correct spec type should match (multiple spaces)": {
+			specYaml: `version:         "prometheus/v1"      `,
+			exp:      true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			loader := prometheus.NewYAMLSpecLoader(testMemPluginsRepo(map[string]prometheus.SLIPlugin{}))
+			got := loader.IsSpecType(context.TODO(), []byte(test.specYaml))
+
+			assert.Equal(test.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
This PR changes how we load the specs on the `validate` and `generate` commands. Before this, we would try loading every type as a chain of spec loaders. Now we instead infer the spec type before loading them.

- It should improve the performance because we don't try loading all the spec, just match some small precompiled regexes.
- The errors are cleaner because now we know that when a spec loader fails, is because is not a valid, not because is not of the type trying to load.