### PR TITLE
Support deployment via Helm to kube 1.19 clusters

### DIFF
--- a/deploy/kubernetes/helm/Chart.yaml
+++ b/deploy/kubernetes/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0"
-version: 0.1.0
+version: 0.2.0

--- a/deploy/kubernetes/helm/Chart.yaml
+++ b/deploy/kubernetes/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: sloth
 description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
-kubeVersion: ">= 1.20.0"
+kubeVersion: ">= 1.19.0"
 version: 0.1.0

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.1.0
+        helm.sh/chart: sloth-0.2.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.1.0
+        helm.sh/chart: sloth-0.2.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.1.0
+        helm.sh/chart: sloth-0.2.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/sa_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/sa_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/sa_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/sa_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.1.0
+    helm.sh/chart: sloth-0.2.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth


### PR DESCRIPTION
First, thank you for the Sloth project! This kind of tool is sorely needed to take much of the toil out of generating SLO-based  metrics, visualizations, and alerts 😀 

We want to use the Helm deploy method and would love to stay in sync with upstream, but are running a 1.19 cluster at the moment.

```
score-sloth                       sloth                              False   Helm install failed: chart requires kubeVersion: >= 1.20.0 which is incompatible with Kubernetes v1.19.12-gke.2101   17h
```

This change would relax the chart's version restriction by a minor kube version. It seemed like this wouldn't be problematic, since CI already tests against kube 1.19?
https://github.com/slok/sloth/blob/3f0d37f2a184bb8560357c82bc51265ceac0bb7f/.github/workflows/ci.yaml#L69-L71