### PR TITLE
Fix/add Helm deploy support for GKE and EKS

### DIFF
--- a/deploy/kubernetes/helm/Chart.yaml
+++ b/deploy/kubernetes/helm/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.2.0
+version: 0.3.0

--- a/deploy/kubernetes/helm/Chart.yaml
+++ b/deploy/kubernetes/helm/Chart.yaml
@@ -3,5 +3,5 @@ name: sloth
 description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 version: 0.2.0

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_binding_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/cluster_role_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/cluster_role_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.2.0
+        helm.sh/chart: sloth-0.3.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.2.0
+        helm.sh/chart: sloth-0.3.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.2.0
+        helm.sh/chart: sloth-0.3.0
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/pod_monitor_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/sa_custom.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/sa_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/tests/testdata/output/sa_default.yaml
+++ b/deploy/kubernetes/helm/tests/testdata/output/sa_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.2.0
+    helm.sh/chart: sloth-0.3.0
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth


### PR DESCRIPTION
### Problem

Helm deployment will fail to any GKE or EKS cluster, due to:
https://github.com/helm/helm/issues/3810

Example error message:
```
Helm install failed: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes 1.20.9-gke.1001
```

### Why it's happening

GKE and EKS identify their kube server versions using semver's "pre-release" syntax (ex. GKE might report a version string like `1.20.8-gke.2100`).

> A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version.
> https://semver.org/spec/v2.0.0.html

Helm's semver library implements the semver spec by failing to match pre-release versions unless the constraint explicitly allows pre-releases (ex. the constraint `>=1.19.0-0`).

> This includes considering prereleases to be invalid if the ranges does not include one. If you want to have it include pre-releases a simple solution is to include -0 in your range.
> https://github.com/Masterminds/semver/tree/49c09bfed6adcffa16482ddc5e5588cffff9883a#checking-version-constraints

---

### References

The solution looks to be a common pattern amongst other popular open source charts. Ex:
* nginx ingress: https://github.com/kubernetes/ingress-nginx/blob/be9a7bea4a3b2f89ec7620dd0056f8fc3bbd6063/charts/ingress-nginx/Chart.yaml#L19
* Vault: https://github.com/hashicorp/vault-helm/pull/512
* promstack: https://github.com/prometheus-community/helm-charts/pull/128