### PR TITLE
Refactor how alert windows are implemented and calculated to allow using different full period windows like 28 day

### DIFF
--- a/internal/alert/alert_test.go
+++ b/internal/alert/alert_test.go
@@ -16,15 +16,6 @@ func TestGenerateMWMBAlerts(t *testing.T) {
 		expAlerts *alert.MWMBAlertGroup
 		expErr    bool
 	}{
-		"Generating alerts different to 30 day time window should fail.": {
-			slo: alert.SLO{
-				ID:         "test",
-				TimeWindow: 31 * 24 * time.Hour,
-				Objective:  99.9,
-			},
-			expErr: true,
-		},
-
 		"Generating a 30 day time window alerts should generate the alerts correctly.": {
 			slo: alert.SLO{
 				ID:         "test",
@@ -62,6 +53,49 @@ func TestGenerateMWMBAlerts(t *testing.T) {
 					ShortWindow:    6 * time.Hour,
 					LongWindow:     3 * 24 * time.Hour,
 					BurnRateFactor: 1,
+					ErrorBudget:    0.09999999999999432,
+					Severity:       alert.TicketAlertSeverity,
+				},
+			},
+		},
+
+		"Generating a 28 day time window alerts should generate the alerts correctly.": {
+			slo: alert.SLO{
+				ID:         "test",
+				TimeWindow: 28 * 24 * time.Hour,
+				Objective:  99.9,
+			},
+			expAlerts: &alert.MWMBAlertGroup{
+				PageQuick: alert.MWMBAlert{
+					ID:             "test-page-quick",
+					ShortWindow:    5 * time.Minute,
+					LongWindow:     1 * time.Hour,
+					BurnRateFactor: 13.44,
+					ErrorBudget:    0.09999999999999432,
+					Severity:       alert.PageAlertSeverity,
+				},
+				PageSlow: alert.MWMBAlert{
+					ID:             "test-page-slow",
+					ShortWindow:    30 * time.Minute,
+					LongWindow:     6 * time.Hour,
+					BurnRateFactor: 5.6000000000000005,
+					ErrorBudget:    0.09999999999999432,
+					Severity:       alert.PageAlertSeverity,
+				},
+
+				TicketQuick: alert.MWMBAlert{
+					ID:             "test-ticket-quick",
+					ShortWindow:    2 * time.Hour,
+					LongWindow:     1 * 24 * time.Hour,
+					BurnRateFactor: 2.8000000000000003,
+					ErrorBudget:    0.09999999999999432,
+					Severity:       alert.TicketAlertSeverity,
+				},
+				TicketSlow: alert.MWMBAlert{
+					ID:             "test-ticket-slow",
+					ShortWindow:    6 * time.Hour,
+					LongWindow:     3 * 24 * time.Hour,
+					BurnRateFactor: 0.9333333333333333,
 					ErrorBudget:    0.09999999999999432,
 					Severity:       alert.TicketAlertSeverity,
 				},


### PR DESCRIPTION
This is only a refactor of how the time windows and speeds are calculated so its less hardcoded and more dynamic, for now, the user will not notice any kind of change, but opens the door to allow different time windows in the future like #96 