### PR TITLE
Poke helm chart to force release

### DIFF
--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -1,4 +1,3 @@
-
 labels: {}
 
 image:


### PR DESCRIPTION
Seems that Helm chart releaser checks changes from the latest tag, so if we change the chart at the same time that we tag the release and the CI us run, this will not detect changes. So we are poking to force the chart release