### PR TITLE
Helm: fix typo from extra-lables to extra-labels

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.4.0
+version: 0.4.1

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - --label-selector={{ .Values.sloth.labelSelector }}
             {{- end}}
             {{- range $key, $val := .Values.sloth.extraLabels }}
-            - --extra-lables={{ $key }}={{ $val }}
+            - --extra-labels={{ $key }}={{ $val }}
             {{- end}}
             {{- if .Values.commonPlugins.enabled }}
             - --sli-plugins-path=/plugins

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/configmap_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/configmap_slo_config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -41,8 +41,8 @@ spec:
             - --workers=99
             - --namespace=somens
             - --label-selector=x=y,z!=y
-            - --extra-lables=k1=v1
-            - --extra-lables=k2=v2
+            - --extra-labels=k1=v1
+            - --extra-labels=k2=v2
             - --sli-plugins-path=/plugins
           ports:
             - containerPort: 8081

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -41,8 +41,8 @@ spec:
             - --workers=99
             - --namespace=somens
             - --label-selector=x=y,z!=y
-            - --extra-lables=k1=v1
-            - --extra-lables=k2=v2
+            - --extra-labels=k1=v1
+            - --extra-labels=k2=v2
           resources:
             limits:
               memory: 150Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -42,8 +42,8 @@ spec:
             - --workers=99
             - --namespace=somens
             - --label-selector=x=y,z!=y
-            - --extra-lables=k1=v1
-            - --extra-lables=k2=v2
+            - --extra-labels=k1=v1
+            - --extra-labels=k2=v2
             - --slo-period-windows-path=/windows
           ports:
             - containerPort: 8081

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
+++ b/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -59,7 +59,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
@@ -130,7 +130,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/raw/sloth.yaml
+++ b/deploy/kubernetes/raw/sloth.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -59,7 +59,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.0
+        helm.sh/chart: sloth-0.4.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
@@ -106,7 +106,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.4.0
+    helm.sh/chart: sloth-0.4.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth


### PR DESCRIPTION
This is a very simple typo fix in the heml chart, the string `extra-lables` -> `extra-labels`.

Updated the Chart version to `0.4.1` manually, but in case this is not needed please let me know and will revert it back