### PR TITLE
Update Chart.yaml: clarify helm repo URL and usage

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: sloth
-description: Base chart for Sloth.
-type: application
+description: Base chart for Sloth. Use `helm repo add slok https://slok.github.io/sloth`, `helm repo update` and `helm upgrade -i sloth slok/sloth`.type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
 version: 0.4.1


### PR DESCRIPTION
It is not obvious what helm repo url should be used.

Helm releaser action use chart description by default for release description, lets use it.