### PR TITLE
Allow disabling optimized recording rules for full period window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Support Kubernetes v1.23
+- Allow disabling optimized rules using `--disable-optimized-rules`. These will disable the period window (e.g 30d) to be as the other window rules and not be optimized.
 
 ## [v0.9.0] - 2021-11-15
 

--- a/cmd/sloth/commands/validate.go
+++ b/cmd/sloth/commands/validate.go
@@ -138,7 +138,7 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			case promYAMLLoader.IsSpecType(ctx, dataB):
 				slos, promErr := promYAMLLoader.LoadSpec(ctx, dataB)
 				if promErr == nil {
-					err := generatePrometheus(ctx, log.Noop, windowsRepo, false, false, v.extraLabels, *slos, io.Discard)
+					err := generatePrometheus(ctx, log.Noop, windowsRepo, false, false, false, v.extraLabels, *slos, io.Discard)
 					if err != nil {
 						validation.Errs = []error{fmt.Errorf("Could not generate Prometheus format rules: %w", err)}
 					}
@@ -150,7 +150,7 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			case kubeYAMLLoader.IsSpecType(ctx, dataB):
 				sloGroup, k8sErr := kubeYAMLLoader.LoadSpec(ctx, dataB)
 				if k8sErr == nil {
-					err := generateKubernetes(ctx, log.Noop, windowsRepo, false, false, v.extraLabels, *sloGroup, io.Discard)
+					err := generateKubernetes(ctx, log.Noop, windowsRepo, false, false, false, v.extraLabels, *sloGroup, io.Discard)
 					if err != nil {
 						validation.Errs = []error{fmt.Errorf("could not generate Kubernetes format rules: %w", err)}
 					}
@@ -162,7 +162,7 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 			case openSLOYAMLLoader.IsSpecType(ctx, dataB):
 				slos, openSLOErr := openSLOYAMLLoader.LoadSpec(ctx, dataB)
 				if openSLOErr == nil {
-					err := generateOpenSLO(ctx, log.Noop, windowsRepo, false, false, v.extraLabels, *slos, io.Discard)
+					err := generateOpenSLO(ctx, log.Noop, windowsRepo, false, false, false, v.extraLabels, *slos, io.Discard)
 					if err != nil {
 						validation.Errs = []error{fmt.Errorf("Could not generate OpenSLO format rules: %w", err)}
 					}

--- a/internal/app/generate/prometheus.go
+++ b/internal/app/generate/prometheus.go
@@ -27,7 +27,7 @@ func (c *ServiceConfig) defaults() error {
 	}
 
 	if c.SLIRecordingRulesGenerator == nil {
-		c.SLIRecordingRulesGenerator = prometheus.SLIRecordingRulesGenerator
+		c.SLIRecordingRulesGenerator = prometheus.OptimizedSLIRecordingRulesGenerator
 	}
 
 	if c.MetaRecordingRulesGenerator == nil {

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -21,9 +21,24 @@ type sliRecordingRulesGenerator struct {
 	genFunc sliRulesgenFunc
 }
 
+// OptimizedSLIRecordingRulesGenerator knows how to generate the SLI prometheus recording rules
+// from an SLO optimizing where it can.
+// Normally these rules are used by the SLO alerts.
+var OptimizedSLIRecordingRulesGenerator = sliRecordingRulesGenerator{genFunc: optimizedFactorySLIRecordGenerator}
+
 // SLIRecordingRulesGenerator knows how to generate the SLI prometheus recording rules
-// form an SLO. Normally these rules are used by the SLO alerts.
+// form an SLO.
+// Normally these rules are used by the SLO alerts.
 var SLIRecordingRulesGenerator = sliRecordingRulesGenerator{genFunc: factorySLIRecordGenerator}
+
+func optimizedFactorySLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+	// Optimize the rules that are for the total period time window.
+	if window == slo.TimeWindow {
+		return optimizedSLIRecordGenerator(slo, window, alerts.PageQuick.ShortWindow)
+	}
+
+	return factorySLIRecordGenerator(slo, window, alerts)
+}
 
 func (s sliRecordingRulesGenerator) GenerateSLIRecordingRules(ctx context.Context, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	// Get the windows we need the recording rules.
@@ -49,9 +64,6 @@ const (
 
 func factorySLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
 	switch {
-	// Optimize the rules that are for the total period time window.
-	case window == slo.TimeWindow:
-		return optimizedSLIRecordGenerator(slo, window, alerts.PageQuick.ShortWindow)
 	// Event based SLI.
 	case slo.SLI.Events != nil:
 		return eventsSLIRecordGenerator(slo, window, alerts)

--- a/scripts/examplesgen.sh
+++ b/scripts/examplesgen.sh
@@ -4,13 +4,16 @@ set -efCo pipefail
 export SHELLOPTS
 IFS=$'\t\n'
 
-command -v go >/dev/null 2>&1 || { echo 'please install go'; exit 1; }
+command -v go >/dev/null 2>&1 || {
+    echo 'please install go'
+    exit 1
+}
 
 SLOS_PATH="${SLOS_PATH:-./examples}"
-[ -z "$SLOS_PATH" ] && echo "SLOS_PATH env is needed" && exit 1;
+[ -z "$SLOS_PATH" ] && echo "SLOS_PATH env is needed" && exit 1
 
 GEN_PATH="${GEN_PATH:-./examples/_gen}"
-[ -z "$GEN_PATH" ] && echo "GEN_PATH env is needed" && exit 1;
+[ -z "$GEN_PATH" ] && echo "GEN_PATH env is needed" && exit 1
 
 mkdir -p "${GEN_PATH}"
 


### PR DESCRIPTION
Fixes #241 

This PR adds a new flag (`--disable-optimized-rules`) on Kubernetes and CLI modes to disable full period optimized rules (e.g 30 day). If disabled the generated SLI recording rules will be like the rest.