### PR TITLE
Add ability to generate from a directory by discovering SLOs and store generated rules on another directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Support Kubernetes v1.23
 - Allow disabling optimized rules using `--disable-optimized-rules`. These will disable the period window (e.g 30d) to be as the other window rules and not be optimized.
+- `generate` command now accepts a directory that will discover SLOs and generate with the same structure in an output directory.
+- Added `--fs-exclude` and `--fs-include` flags to `generate` command, that will be used when generate inputs are a directory.
 
 ## [v0.9.0] - 2021-11-15
 

--- a/scripts/examplesgen.sh
+++ b/scripts/examplesgen.sh
@@ -17,13 +17,6 @@ GEN_PATH="${GEN_PATH:-./examples/_gen}"
 
 mkdir -p "${GEN_PATH}"
 
-set +f # Allow asterisk expansion.
-
 # We already know that we are building sloth for each SLO, good enough, this way we can check
 # the current development version.
-for file in ${SLOS_PATH}/*.yml; do
-    fname=$(basename "$file")
-    go run ./cmd/sloth/ generate -i "${file}" -o "${GEN_PATH}/${fname}" -p "${SLOS_PATH}" --extra-labels "cmd=examplesgen.sh"
-done
-
-set -f
+go run ./cmd/sloth/ generate -i "${SLOS_PATH}" -o "${GEN_PATH}" -p "${SLOS_PATH}" --extra-labels "cmd=examplesgen.sh" -e "_gen|windows"


### PR DESCRIPTION
Fixes #252 

This PR adds support for SLO generation from a directory instead of a single file. The discovery is done automatically, Sloth will check if the input is a file or a directory, and based on that it will execute in single file mode or dir mode.

Also adds `--fs-exclude` and `--fs-include` as in the `validate` command.

The output files will be in the same structure as the input files.

### Execution example:

```bash
sloth -p ./examples/plugins/ -i ./test-examples/ -o ./out-examples/
```

<details>
	<summary>Input file tree</summary>

```text
./test-examples/
├── getting-started.yml
├── home-wifi.yml
├── k8s-getting-started.yml
├── k8s-home-wifi.yml
├── k8s-multifile.yml
├── kubernetes-apiserver.yml
├── l1
│   ├── getting-started.yml
│   ├── home-wifi.yml
│   ├── k8s-getting-started.yml
│   ├── k8s-home-wifi.yml
│   ├── k8s-multifile.yml
│   ├── kubernetes-apiserver.yml
│   ├── l11
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── l12
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── l121
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── l122
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── multifile.yml
│   ├── no-alerts.yml
│   ├── openslo-getting-started.yml
│   ├── openslo-kubernetes-apiserver.yml
│   ├── plugin-getting-started.yml
│   ├── plugin-k8s-getting-started.yml
│   └── raw-home-wifi.yml
├── l2
│   ├── getting-started.yml
│   ├── home-wifi.yml
│   ├── k8s-getting-started.yml
│   ├── k8s-home-wifi.yml
│   ├── k8s-multifile.yml
│   ├── kubernetes-apiserver.yml
│   ├── l22
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── l122
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── l221
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── l2211
│   │   │   │   ├── getting-started.yml
│   │   │   │   ├── home-wifi.yml
│   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   ├── k8s-multifile.yml
│   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   ├── l22111
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── l22112
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── l22113
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── multifile.yml
│   │   │   │   ├── no-alerts.yml
│   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   └── raw-home-wifi.yml
│   │   │   ├── l2212
│   │   │   │   ├── getting-started.yml
│   │   │   │   ├── home-wifi.yml
│   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   ├── k8s-multifile.yml
│   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   ├── multifile.yml
│   │   │   │   ├── no-alerts.yml
│   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   └── raw-home-wifi.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── multifile.yml
│   ├── no-alerts.yml
│   ├── openslo-getting-started.yml
│   ├── openslo-kubernetes-apiserver.yml
│   ├── plugin-getting-started.yml
│   ├── plugin-k8s-getting-started.yml
│   └── raw-home-wifi.yml
├── multifile.yml
├── no-alerts.yml
├── openslo-getting-started.yml
├── openslo-kubernetes-apiserver.yml
├── plugin-getting-started.yml
├── plugin-k8s-getting-started.yml
└── raw-home-wifi.yml

14 directories, 195 files
```
</details>

<details>
	<summary>Out file tree</summary>

```text
./out-examples/
├── getting-started.yml
├── home-wifi.yml
├── k8s-getting-started.yml
├── k8s-home-wifi.yml
├── k8s-multifile.yml
├── kubernetes-apiserver.yml
├── l1
│   ├── getting-started.yml
│   ├── home-wifi.yml
│   ├── k8s-getting-started.yml
│   ├── k8s-home-wifi.yml
│   ├── k8s-multifile.yml
│   ├── kubernetes-apiserver.yml
│   ├── l11
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── l12
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── l121
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── l122
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── multifile.yml
│   ├── no-alerts.yml
│   ├── openslo-getting-started.yml
│   ├── openslo-kubernetes-apiserver.yml
│   ├── plugin-getting-started.yml
│   ├── plugin-k8s-getting-started.yml
│   └── raw-home-wifi.yml
├── l2
│   ├── getting-started.yml
│   ├── home-wifi.yml
│   ├── k8s-getting-started.yml
│   ├── k8s-home-wifi.yml
│   ├── k8s-multifile.yml
│   ├── kubernetes-apiserver.yml
│   ├── l22
│   │   ├── getting-started.yml
│   │   ├── home-wifi.yml
│   │   ├── k8s-getting-started.yml
│   │   ├── k8s-home-wifi.yml
│   │   ├── k8s-multifile.yml
│   │   ├── kubernetes-apiserver.yml
│   │   ├── l122
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── l221
│   │   │   ├── getting-started.yml
│   │   │   ├── home-wifi.yml
│   │   │   ├── k8s-getting-started.yml
│   │   │   ├── k8s-home-wifi.yml
│   │   │   ├── k8s-multifile.yml
│   │   │   ├── kubernetes-apiserver.yml
│   │   │   ├── l2211
│   │   │   │   ├── getting-started.yml
│   │   │   │   ├── home-wifi.yml
│   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   ├── k8s-multifile.yml
│   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   ├── l22111
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── l22112
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── l22113
│   │   │   │   │   ├── getting-started.yml
│   │   │   │   │   ├── home-wifi.yml
│   │   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   │   ├── k8s-multifile.yml
│   │   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   │   ├── multifile.yml
│   │   │   │   │   ├── no-alerts.yml
│   │   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   │   └── raw-home-wifi.yml
│   │   │   │   ├── multifile.yml
│   │   │   │   ├── no-alerts.yml
│   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   └── raw-home-wifi.yml
│   │   │   ├── l2212
│   │   │   │   ├── getting-started.yml
│   │   │   │   ├── home-wifi.yml
│   │   │   │   ├── k8s-getting-started.yml
│   │   │   │   ├── k8s-home-wifi.yml
│   │   │   │   ├── k8s-multifile.yml
│   │   │   │   ├── kubernetes-apiserver.yml
│   │   │   │   ├── multifile.yml
│   │   │   │   ├── no-alerts.yml
│   │   │   │   ├── openslo-getting-started.yml
│   │   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   │   ├── plugin-getting-started.yml
│   │   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   │   └── raw-home-wifi.yml
│   │   │   ├── multifile.yml
│   │   │   ├── no-alerts.yml
│   │   │   ├── openslo-getting-started.yml
│   │   │   ├── openslo-kubernetes-apiserver.yml
│   │   │   ├── plugin-getting-started.yml
│   │   │   ├── plugin-k8s-getting-started.yml
│   │   │   └── raw-home-wifi.yml
│   │   ├── multifile.yml
│   │   ├── no-alerts.yml
│   │   ├── openslo-getting-started.yml
│   │   ├── openslo-kubernetes-apiserver.yml
│   │   ├── plugin-getting-started.yml
│   │   ├── plugin-k8s-getting-started.yml
│   │   └── raw-home-wifi.yml
│   ├── multifile.yml
│   ├── no-alerts.yml
│   ├── openslo-getting-started.yml
│   ├── openslo-kubernetes-apiserver.yml
│   ├── plugin-getting-started.yml
│   ├── plugin-k8s-getting-started.yml
│   └── raw-home-wifi.yml
├── multifile.yml
├── no-alerts.yml
├── openslo-getting-started.yml
├── openslo-kubernetes-apiserver.yml
├── plugin-getting-started.yml
├── plugin-k8s-getting-started.yml
└── raw-home-wifi.yml

14 directories, 195 files
```
</details>