### PR TITLE
Helm support for disabling optimized flag

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.4.2
+version: 0.4.3

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             {{- with .Values.sloth.defaultSloPeriod }}
             - --default-slo-period={{ . }}
             {{- end }}
+            {{- if not .Values.sloth.optimizedRules }}
+            - --disable-optimized-rules
+            {{- end }}
             {{- if .Values.customSloConfig.enabled }}
             - --slo-period-windows-path={{ .Values.customSloConfig.path }}
             {{- end }}

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -61,7 +61,7 @@ func TestChartServiceAccount(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -140,7 +140,7 @@ func TestChartDeployment(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -204,7 +204,7 @@ func TestChartPodMonitor(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -257,7 +257,7 @@ func TestChartClusterRole(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -310,7 +310,7 @@ func TestChartClusterRoleBinding(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -365,8 +365,13 @@ func TestChartConfigMap(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, gotTpl)
+				assert.Equal(expTplS, NormalizeVersion(gotTpl))
 			}
 		})
 	}
+}
+
+func NormalizeVersion(tpl string) string {
+	var versionNormalizer = regexp.MustCompile(`helm\.sh/chart: sloth-[0-9\\.]+`)
+	return versionNormalizer.ReplaceAllString(tpl, "helm.sh/chart: sloth-<version>")
 }

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const chartDir = "../"
+var versionNormalizer = regexp.MustCompile(`helm\.sh/chart: sloth-[0-9\\.]+`)
 
 func TestChartServiceAccount(t *testing.T) {
 	tests := map[string]struct {
@@ -61,7 +62,7 @@ func TestChartServiceAccount(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -140,7 +141,7 @@ func TestChartDeployment(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -204,7 +205,7 @@ func TestChartPodMonitor(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -257,7 +258,7 @@ func TestChartClusterRole(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -310,7 +311,7 @@ func TestChartClusterRoleBinding(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
@@ -365,13 +366,12 @@ func TestChartConfigMap(t *testing.T) {
 				require.NoError(err)
 				expTplS := strings.TrimSpace(string(expTpl))
 
-				assert.Equal(expTplS, NormalizeVersion(gotTpl))
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
 			}
 		})
 	}
 }
 
-func NormalizeVersion(tpl string) string {
-	var versionNormalizer = regexp.MustCompile(`helm\.sh/chart: sloth-[0-9\\.]+`)
+func normalizeVersion(tpl string) string {
 	return versionNormalizer.ReplaceAllString(tpl, "helm.sh/chart: sloth-<version>")
 }

--- a/deploy/kubernetes/helm/sloth/tests/testdata/input/custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/input/custom.yaml
@@ -12,6 +12,7 @@ sloth:
   workers: 99
   labelSelector: "x=y,z!=y"
   namespace: "somens"
+  optimizedRules: false
   extraLabels:
     k1: v1
     k2: v2

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_binding_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_custom.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth-test
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/cluster_role_default.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/configmap_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/configmap_slo_config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -44,6 +44,7 @@ spec:
             - --extra-labels=k1=v1
             - --extra-labels=k2=v2
             - --sli-plugins-path=/plugins
+            - --disable-optimized-rules
           ports:
             - containerPort: 8081
               name: metrics

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.2
+        helm.sh/chart: sloth-<version>
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -43,6 +43,7 @@ spec:
             - --label-selector=x=y,z!=y
             - --extra-labels=k1=v1
             - --extra-labels=k2=v2
+            - --disable-optimized-rules
           resources:
             limits:
               memory: 150Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.2
+        helm.sh/chart: sloth-<version>
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -44,6 +44,7 @@ spec:
             - --label-selector=x=y,z!=y
             - --extra-labels=k1=v1
             - --extra-labels=k2=v2
+            - --disable-optimized-rules
             - --slo-period-windows-path=/windows
           ports:
             - containerPort: 8081

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.2
+        helm.sh/chart: sloth-<version>
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: sloth
       containers:
         - name: sloth
-          image: ghcr.io/slok/sloth:v0.9.0
+          image: ghcr.io/slok/sloth:v0.10.0
           args:
             - kubernetes-controller
             - --sli-plugins-path=/plugins

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.4.2
+        helm.sh/chart: sloth-<version>
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/pod_monitor_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_custom.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth-test
   namespace: custom
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/sa_default.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: default
   labels:
-    helm.sh/chart: sloth-0.4.2
+    helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -2,7 +2,7 @@ labels: {}
 
 image:
   repository: ghcr.io/slok/sloth
-  tag: v0.9.0
+  tag: v0.10.0
 
 sloth:
   resyncInterval: ""    # The controller resync interval duration (e.g 15m).

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -10,7 +10,8 @@ sloth:
   labelSelector: ""     # Sloth will handle only the ones that match the selector.
   namespace: ""         # The namespace where sloth will the CRs to process.
   extraLabels: {}       # Labels that will be added to all the generated SLO Rules.
-  defaultSloPeriod: ""  # The slo period used by sloth (e.g. 30d)
+  defaultSloPeriod: ""  # The slo period used by sloth (e.g. 30d).
+  optimizedRules: true  # Reduce prom load for calculating period window burnrates.
   debug:
     enabled: false
 


### PR DESCRIPTION
Chart support for #259.
Also reduced the amount edits needed to test cases with a helm version bump. Hope that is appreciated.
Let me know if you'd prefer something like `extraArgs` instead of enumerating all arg options in chart. 

Will need a new docker release and a bit of testing as well

