### PR TITLE
Add nindent to prometheusLabels

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.5.0
+version: 0.5.1

--- a/deploy/kubernetes/helm/sloth/templates/pod-monitor.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/pod-monitor.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "sloth.labels" . | nindent 4 }}
     {{- with .Values.metrics.prometheusLabels }}
-    {{ toYaml . }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:


### PR DESCRIPTION
```yaml
metrics:
  prometheusLabels:
    release: prometheus-operator
    app: kube-prometheus-stack
```

When adding multiple labels like example above, indentation is getting screwed. Resulting in this:

```yaml
---
# Source: sloth/templates/pod-monitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: ep-sloth
  namespace: sloth-test
  labels:
    helm.sh/chart: sloth-0.5.0
    app.kubernetes.io/managed-by: Helm
    app: sloth
    app.kubernetes.io/name: sloth
    app.kubernetes.io/instance: ep-sloth
    app: kube-prometheus-stack
release: prometheus-operator <<------
spec:
  selector:
    matchLabels:
      app: sloth
      app.kubernetes.io/name: sloth
      app.kubernetes.io/instance: ep-sloth
  podMetricsEndpoints:
    - port: metrics
```

This fixes this behavior.