### PR TITLE
Make git-sync image repo and tag configurable

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.5.1
+version: 0.5.2

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
               memory: 75Mi
         {{- if .Values.commonPlugins.enabled }}
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.3.4
+          image: {{ .Values.commonPlugins.image.repository }}:{{ .Values.commonPlugins.image.tag }}
           args:
             - --repo={{.Values.commonPlugins.gitRepo.url}}
             - --branch={{.Values.commonPlugins.gitRepo.branch}}

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -17,6 +17,9 @@ sloth:
 
 commonPlugins:
   enabled: true
+  image:
+    repository: k8s.gcr.io/git-sync/git-sync
+    tag: v3.3.4
   gitRepo:
     url: https://github.com/slok/sloth-common-sli-plugins
     branch: main


### PR DESCRIPTION
### Why?

k8s.gcr.io is blocked in China. This commit makes `k8s.gcr.io/git-sync/git-sync` configurable in Helm values so it can be pulled from alternative repositories.