### PR TITLE
feat: add securityContext for pod and container

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "sloth.fullname" . }}
+      securityContext:
+        {{- with .Values.securityContext.pod }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: sloth
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -75,6 +79,10 @@ spec:
               mountPath: {{ .Values.customSloConfig.path }}
           {{- end }}
           {{- end }}
+          securityContext:
+            {{- with .Values.securityContext.container }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             limits:
               memory: 150Mi
@@ -97,6 +105,10 @@ spec:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.
               mountPath: /tmp/git
+          securityContext:
+            {{- with .Values.securityContext.container }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             limits:
               memory: 100Mi

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -390,10 +390,10 @@ func TestChartSecurityContext(t *testing.T) {
 		},
 
 		"A chart with custom security values should render correctly.": {
-			name:       "test",
-			namespace:  "custom",
+			name:      "test",
+			namespace: "custom",
 			values: func() map[string]interface{} {
-				v := customValues()
+				v := securityValues()
 				v["securityContext"].(msi)["enabled"] = true
 
 				return v

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -373,3 +373,62 @@ func TestChartConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func TestChartSecurityContext(t *testing.T) {
+	tests := map[string]struct {
+		name       string
+		namespace  string
+		values     func() map[string]interface{}
+		expErr     bool
+		expTplFile string
+	}{
+		"A chart without security values should render correctly.": {
+			name:       "sloth",
+			namespace:  "default",
+			values:     defaultValues,
+			expTplFile: "testdata/output/deployment_default.yaml",
+		},
+
+		"A chart with custom security values should render correctly.": {
+			name:       "test",
+			namespace:  "custom",
+			values: func() map[string]interface{} {
+				v := customValues()
+				v["securityContext"].(msi)["enabled"] = true
+
+				return v
+			},
+			expTplFile: "testdata/output/deployment_securityContext.yaml",
+		}
+	}
+
+	checksumNormalizer := regexp.MustCompile(`checksum/config: [a-z0-9]+`)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			gotTpl, err := helm.Template(context.TODO(), helm.TemplateConfig{
+				Chart:       slothChart,
+				Namespace:   test.namespace,
+				ReleaseName: test.name,
+				Values:      test.values(),
+				ShowFiles:   []string{"templates/deployment.yaml"},
+			})
+
+			// Check.
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				gotTpl := checksumNormalizer.ReplaceAllString(gotTpl, "checksum/config: <checksum>")
+
+				expTpl, err := os.ReadFile(test.expTplFile)
+				require.NoError(err)
+				expTplS := strings.TrimSpace(string(expTpl))
+
+				assert.Equal(expTplS, normalizeVersion(gotTpl))
+			}
+		})
+	}
+}

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -399,7 +399,7 @@ func TestChartSecurityContext(t *testing.T) {
 				return v
 			},
 			expTplFile: "testdata/output/deployment_securityContext.yaml",
-		}
+		},
 	}
 
 	checksumNormalizer := regexp.MustCompile(`checksum/config: [a-z0-9]+`)

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -32,6 +32,7 @@ spec:
         kubectl.kubernetes.io/default-container: sloth
     spec:
       serviceAccountName: sloth-test
+      securityContext:
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42
@@ -52,6 +53,7 @@ spec:
           volumeMounts:
             - name: sloth-common-sli-plugins
               mountPath: /plugins/sloth-common-sli-plugins
+          securityContext:
           resources:
             limits:
               memory: 150Mi
@@ -69,6 +71,7 @@ spec:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.
               mountPath: /tmp/git
+          securityContext:
           resources:
             limits:
               memory: 100Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -56,6 +56,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 150Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -61,7 +61,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.3.4
+          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-test-common-sli-plugins
             - --branch=main
@@ -74,6 +74,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -48,6 +48,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 150Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -32,6 +32,7 @@ spec:
         kubectl.kubernetes.io/default-container: sloth
     spec:
       serviceAccountName: sloth-test
+      securityContext:
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42
@@ -44,6 +45,7 @@ spec:
             - --extra-labels=k1=v1
             - --extra-labels=k2=v2
             - --disable-optimized-rules
+          securityContext:
           resources:
             limits:
               memory: 150Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -57,6 +57,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 150Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -33,6 +33,7 @@ spec:
         checksum/config: <checksum>
     spec:
       serviceAccountName: sloth-test
+      securityContext:
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42
@@ -53,6 +54,7 @@ spec:
           volumeMounts:
             - name: sloth-windows
               mountPath: /windows
+          securityContext:
           resources:
             limits:
               memory: 150Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -33,7 +33,7 @@ spec:
       securityContext:
       containers:
         - name: sloth
-          image: ghcr.io/slok/sloth:v0.10.0
+          image: ghcr.io/slok/sloth:v0.11.0
           args:
             - kubernetes-controller
             - --sli-plugins-path=/plugins
@@ -52,7 +52,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.3.4
+          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main
@@ -65,6 +65,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -30,6 +30,7 @@ spec:
         kubectl.kubernetes.io/default-container: sloth
     spec:
       serviceAccountName: sloth
+      securityContext:
       containers:
         - name: sloth
           image: ghcr.io/slok/sloth:v0.10.0
@@ -43,6 +44,7 @@ spec:
           volumeMounts:
             - name: sloth-common-sli-plugins
               mountPath: /plugins/sloth-common-sli-plugins
+          securityContext:
           resources:
             limits:
               memory: 150Mi
@@ -60,6 +62,7 @@ spec:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.
               mountPath: /tmp/git
+          securityContext:
           resources:
             limits:
               memory: 100Mi

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -47,6 +47,7 @@ spec:
           securityContext:
           resources:
             limits:
+              cpu: 50m
               memory: 150Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
@@ -3,22 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sloth-test
-  namespace: custom
+  name: sloth
+  namespace: default
   labels:
     helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
-    app.kubernetes.io/instance: test
-    label-from: test
+    app.kubernetes.io/instance: sloth
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: sloth
       app.kubernetes.io/name: sloth
-      app.kubernetes.io/instance: test
+      app.kubernetes.io/instance: sloth
   template:
     metadata:
       labels:
@@ -26,12 +25,11 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
-        app.kubernetes.io/instance: test
-        label-from: test
+        app.kubernetes.io/instance: sloth
       annotations:
         kubectl.kubernetes.io/default-container: sloth
     spec:
-      serviceAccountName: sloth-test
+      serviceAccountName: sloth
       securityContext:
         runAsNonRoot: true
         runAsGroup: 1000
@@ -41,17 +39,10 @@ spec:
           - 100
       containers:
         - name: sloth
-          image: slok/sloth-test:v1.42.42
+          image: ghcr.io/slok/sloth:v0.10.0
           args:
             - kubernetes-controller
-            - --resync-interval=17m
-            - --workers=99
-            - --namespace=somens
-            - --label-selector=x=y,z!=y
-            - --extra-labels=k1=v1
-            - --extra-labels=k2=v2
             - --sli-plugins-path=/plugins
-            - --disable-optimized-rules
           ports:
             - containerPort: 8081
               name: metrics
@@ -73,7 +64,7 @@ spec:
         - name: git-sync-plugins
           image: k8s.gcr.io/git-sync/git-sync:v3.3.4
           args:
-            - --repo=https://github.com/slok/sloth-test-common-sli-plugins
+            - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main
             - --wait=30
             - --webhook-url=http://localhost:8082/-/reload

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
@@ -55,6 +55,7 @@ spec:
               drop: ALL
           resources:
             limits:
+              cpu: 50m
               memory: 150Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
@@ -1,0 +1,97 @@
+---
+# Source: sloth/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sloth-test
+  namespace: custom
+  labels:
+    helm.sh/chart: sloth-<version>
+    app.kubernetes.io/managed-by: Helm
+    app: sloth
+    app.kubernetes.io/name: sloth
+    app.kubernetes.io/instance: test
+    label-from: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sloth
+      app.kubernetes.io/name: sloth
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: sloth-<version>
+        app.kubernetes.io/managed-by: Helm
+        app: sloth
+        app.kubernetes.io/name: sloth
+        app.kubernetes.io/instance: test
+        label-from: test
+      annotations:
+        kubectl.kubernetes.io/default-container: sloth
+    spec:
+      serviceAccountName: sloth-test
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 100
+        supplementalGroups:
+          - 100
+      containers:
+        - name: sloth
+          image: slok/sloth-test:v1.42.42
+          args:
+            - kubernetes-controller
+            - --resync-interval=17m
+            - --workers=99
+            - --namespace=somens
+            - --label-selector=x=y,z!=y
+            - --extra-labels=k1=v1
+            - --extra-labels=k2=v2
+            - --sli-plugins-path=/plugins
+            - --disable-optimized-rules
+          ports:
+            - containerPort: 8081
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: sloth-common-sli-plugins
+              mountPath: /plugins/sloth-common-sli-plugins
+          resources:
+            limits:
+              memory: 150Mi
+            requests:
+              cpu: 5m
+              memory: 75Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - name: git-sync-plugins
+          image: k8s.gcr.io/git-sync/git-sync:v3.3.4
+          args:
+            - --repo=https://github.com/slok/sloth-test-common-sli-plugins
+            - --branch=main
+            - --wait=30
+            - --webhook-url=http://localhost:8082/-/reload
+          volumeMounts:
+            - name: sloth-common-sli-plugins
+              # Default path for git-sync.
+              mountPath: /tmp/git
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 5m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: sloth-common-sli-plugins
+          emptyDir: {}

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
@@ -3,21 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sloth
-  namespace: default
+  name: sloth-test
+  namespace: custom
   labels:
     helm.sh/chart: sloth-<version>
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
-    app.kubernetes.io/instance: sloth
+    app.kubernetes.io/instance: test
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: sloth
       app.kubernetes.io/name: sloth
-      app.kubernetes.io/instance: sloth
+      app.kubernetes.io/instance: test
   template:
     metadata:
       labels:
@@ -25,18 +25,17 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
-        app.kubernetes.io/instance: sloth
+        app.kubernetes.io/instance: test
       annotations:
         kubectl.kubernetes.io/default-container: sloth
     spec:
-      serviceAccountName: sloth
+      serviceAccountName: sloth-test
       securityContext:
-        runAsNonRoot: true
-        runAsGroup: 1000
-        runAsUser: 100
         fsGroup: 100
-        supplementalGroups:
-          - 100
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 100
+        supplementalGroups: "100"
       containers:
         - name: sloth
           image: ghcr.io/slok/sloth:v0.10.0
@@ -50,17 +49,16 @@ spec:
           volumeMounts:
             - name: sloth-common-sli-plugins
               mountPath: /plugins/sloth-common-sli-plugins
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ALL
           resources:
             limits:
               memory: 150Mi
             requests:
               cpu: 5m
               memory: 75Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
         - name: git-sync-plugins
           image: k8s.gcr.io/git-sync/git-sync:v3.3.4
           args:
@@ -72,17 +70,16 @@ spec:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.
               mountPath: /tmp/git
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ALL
           resources:
             limits:
               memory: 100Mi
             requests:
               cpu: 5m
               memory: 50Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
       volumes:
         - name: sloth-common-sli-plugins
           emptyDir: {}

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_securityContext.yaml
@@ -38,7 +38,7 @@ spec:
         supplementalGroups: "100"
       containers:
         - name: sloth
-          image: ghcr.io/slok/sloth:v0.10.0
+          image: ghcr.io/slok/sloth:v0.11.0
           args:
             - kubernetes-controller
             - --sli-plugins-path=/plugins
@@ -60,7 +60,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.3.4
+          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main
@@ -76,6 +76,7 @@ spec:
               drop: ALL
           resources:
             limits:
+              cpu: 50m
               memory: 100Mi
             requests:
               cpu: 5m

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -50,5 +50,24 @@ func customValues() msi {
 				"customKey": "customValue",
 			},
 		},
+
+		"securityContext": msi{
+			"pod": msi{
+				"runAsNonRoot": true
+				"runAsGroup": 1000
+				"runAsUser": 100
+				"fsGroup": 100
+				"supplementalGroups": msi{
+					"100",
+				},
+			},
+		  	"container": msi{
+				"allowPrivilegeEscalation": false
+				"capabilities":
+				"drop": msi{
+					"ALL",
+				},
+			},
+		},
 	}
 }

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -53,16 +53,16 @@ func customValues() msi {
 
 		"securityContext": msi{
 			"pod": msi{
-				"runAsNonRoot": true
-				"runAsGroup": 1000
-				"runAsUser": 100
-				"fsGroup": 100
+				"runAsNonRoot": true,
+				"runAsGroup": 1000,
+				"runAsUser": 100,
+				"fsGroup": 100,
 				"supplementalGroups": msi{
 					"100",
 				},
 			},
 		  	"container": msi{
-				"allowPrivilegeEscalation": false
+				"allowPrivilegeEscalation": false,
 				"capabilities":
 				"drop": msi{
 					"ALL",

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -50,22 +50,23 @@ func customValues() msi {
 				"customKey": "customValue",
 			},
 		},
+	}
+}
 
+func securityValues() msi {
+	return msi{
 		"securityContext": msi{
 			"pod": msi{
-				"runAsNonRoot": true,
-				"runAsGroup": 1000,
-				"runAsUser": 100,
-				"fsGroup": 100,
-				"supplementalGroups": msi{
-					"100",
-				},
+				"runAsNonRoot":       true,
+				"runAsGroup":         1000,
+				"runAsUser":          100,
+				"fsGroup":            100,
+				"supplementalGroups": "100",
 			},
-		  	"container": msi{
+			"container": msi{
 				"allowPrivilegeEscalation": false,
-				"capabilities":
-				"drop": msi{
-					"ALL",
+				"capabilities": msi{
+					"drop": "ALL",
 				},
 			},
 		},

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -46,15 +46,5 @@ customSloConfig:
 
 # add securityContext for pod and container level
 securityContext:
-    pod:
-      runAsNonRoot: true
-      runAsGroup: 1000
-      runAsUser: 100
-      fsGroup: 100
-      supplementalGroups:
-        - 100
-    container:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-          - ALL
+    pod: {}
+    container: {}

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -43,3 +43,18 @@ customSloConfig:
 #     operator: Equal
 #     value: spot
 #     effect: NoSchedule
+
+# add securityContext for pod and container level
+securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsGroup: 1000
+      runAsUser: 100
+      fsGroup: 100
+      supplementalGroups:
+        - 100
+    container:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL


### PR DESCRIPTION
What: Deployments can have security settings in their manifest on two levels: pod and container. However, there are some capabilities only configurable in one of the respective levels(https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core). This PR sets a default configuration for container securityContext, which drops all POSIX capabilities and denies privilege escalation and for pod securityContext adds user, group fsGroup and supplementalGroups and also denies root usage.
These are and should be standard settings in the context of Kubernetes. It also adds the possibility of running vault-injector in a Kubernetes environment without PSP (to be removed in v1.25 https://kubernetes.io/docs/concepts/security/pod-security-policy/), but with OpenPolicyAgent (possibly the PSP substitute) with the same capabilities as a restricted PSP instead.

This PR sets the respective settings to the values.yaml and is defaulting them as well. With this they can be adopted if it is needed.