### PR TITLE
feat: add image repository secret 

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
+++ b/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
@@ -39,3 +39,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "sloth.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{- define "sloth.imagePullSecrets" -}}
+{{- range .Values.imagePullSecrets }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
               cpu: 5m
               memory: 50Mi
         {{- end }}
+      {{- if .Values.image.secret.enabled }}
+      imagePullSecrets:
+      - name: {{ .Values.image.secret.name }}
+      {{- end }}
       {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
       volumes:
       {{- if .Values.commonPlugins.enabled }}

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -104,9 +104,9 @@ spec:
               cpu: 5m
               memory: 50Mi
         {{- end }}
-      {{- if .Values.image.secret.enabled }}
+      {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.image.secret.name }}
+{{ include "sloth.imagePullSecrets" . | trim | indent 8 }}
       {{- end }}
       {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
       volumes:

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -3,6 +3,9 @@ labels: {}
 image:
   repository: ghcr.io/slok/sloth
   tag: v0.10.0
+  secret: 
+    enabled: true
+    name: "change-me"
 
 sloth:
   resyncInterval: ""    # The controller resync interval duration (e.g 15m).

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -3,9 +3,11 @@ labels: {}
 image:
   repository: ghcr.io/slok/sloth
   tag: v0.10.0
-  secret: 
-    enabled: true
-    name: "change-me"
+
+imagePullSecrets: []
+#  - name: secret1
+#  - name: secret2
+
 
 sloth:
   resyncInterval: ""    # The controller resync interval duration (e.g 15m).


### PR DESCRIPTION
Why?

people who use private image repository that has security enabled, cant deploy sloth with helm ,

added the pull image secret to enable the use the sloth image on private repos for helm deployments