### PR TITLE
feat: image repository secret lists added

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
+++ b/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
@@ -39,3 +39,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "sloth.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+{{- define "sloth.imagePullSecrets" -}}
+{{- range .Values.imagePullSecrets }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
+++ b/deploy/kubernetes/helm/sloth/templates/_helpers.tpl
@@ -41,10 +41,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- define "sloth.imagePullSecrets" -}}
 {{- range .Values.imagePullSecrets }}
-  {{- if eq (typeOf .) "map[string]interface {}" }}
 - {{ toYaml . | trim }}
-  {{- else }}
-- name: {{ . }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
               cpu: 5m
               memory: 50Mi
         {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ include "sloth.imagePullSecrets" . | trim | indent 8 }}
+      {{- end }}
       {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
       volumes:
       {{- if .Values.commonPlugins.enabled }}

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -4,6 +4,10 @@ image:
   repository: ghcr.io/slok/sloth
   tag: v0.10.0
 
+imagePullSecrets: []
+#  - name: secret1
+#  - name: secret2
+
 sloth:
   resyncInterval: ""    # The controller resync interval duration (e.g 15m).
   workers: 0            # The number of concurrent controller workers (e.g 5).


### PR DESCRIPTION
Why?

people who use private image repository that has security enabled, cant deploy sloth with helm ,

added the pull image secret to enable the use the sloth image on private repos for helm deployments