### PR TITLE
error_ratio_query -> errorRatioQuery

### DIFF
--- a/examples/raw-home-wifi.yml
+++ b/examples/raw-home-wifi.yml
@@ -25,7 +25,7 @@ slos:
     sli:
       raw:
         # Get the averate satisfaction ratio and rest 1 (max good) to get the error ratio.
-        error_ratio_query: |
+        errorRatioQuery: |
           1 - (
             sum(sum_over_time(unifipoller_client_satisfaction_ratio[{{.window}}]))
             /

--- a/internal/prometheus/spec_test.go
+++ b/internal/prometheus/spec_test.go
@@ -180,7 +180,7 @@ slos:
     objective: 99
     sli:
       raw:
-        error_ratio_query: test_expr_ratio_2
+        errorRatioQuery: test_expr_ratio_2
     alerting:
       page_alert:
         disable: true
@@ -247,7 +247,7 @@ slos:
     objective: 99.9
     sli:
       raw:
-        error_ratio_query: test_expr_ratio_2
+        errorRatioQuery: test_expr_ratio_2
     alerting:
       page_alert:
         disable: true

--- a/pkg/prometheus/api/v1/README.md
+++ b/pkg/prometheus/api/v1/README.md
@@ -173,7 +173,7 @@ SLIRaw is a error ratio SLI already calculated. Normally this will be used when 
 ```go
 type SLIRaw struct {
     // ErrorRatioQuery is a Prometheus query that will get the raw error ratio (0-1) for the SLO.
-    ErrorRatioQuery string `yaml:"error_ratio_query"`
+    ErrorRatioQuery string `yaml:"errorRatioQuery"`
 }
 ```
 

--- a/pkg/prometheus/api/v1/v1.go
+++ b/pkg/prometheus/api/v1/v1.go
@@ -109,7 +109,7 @@ type SLI struct {
 // is already calculated by other recording rule, system...
 type SLIRaw struct {
 	// ErrorRatioQuery is a Prometheus query that will get the raw error ratio (0-1) for the SLO.
-	ErrorRatioQuery string `yaml:"error_ratio_query"`
+	ErrorRatioQuery string `yaml:"errorRatioQuery"`
 }
 
 // SLIEvents is an SLI that is calculated as the division of bad events and total events, giving

--- a/test/integration/prometheus/testdata/in-base.yaml
+++ b/test/integration/prometheus/testdata/in-base.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/in-invalid-version.yaml
+++ b/test/integration/prometheus/testdata/in-invalid-version.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/in-multifile.yaml
+++ b/test/integration/prometheus/testdata/in-multifile.yaml
@@ -32,7 +32,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
@@ -76,7 +76,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/bad/bad-aa.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/bad-aa.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/bad/bad-ab.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/bad-ab.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/bad/bad-ba.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/bad-ba.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/bad/bad-multi.yaml
+++ b/test/integration/prometheus/testdata/validate/bad/bad-multi.yaml
@@ -32,7 +32,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/good/good-aa.yaml
+++ b/test/integration/prometheus/testdata/validate/good/good-aa.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/good/good-ab.yaml
+++ b/test/integration/prometheus/testdata/validate/good/good-ab.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/good/good-ba.yaml
+++ b/test/integration/prometheus/testdata/validate/good/good-ba.yaml
@@ -31,7 +31,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))

--- a/test/integration/prometheus/testdata/validate/good/good-multi.yaml
+++ b/test/integration/prometheus/testdata/validate/good/good-multi.yaml
@@ -32,7 +32,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
@@ -76,7 +76,7 @@ slos:
       global03k1: global03v1
     sli:
       raw:
-        error_ratio_query: |
+        errorRatioQuery: |
           sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
           /
           sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))


### PR DESCRIPTION
When writing raw SLOs using sloth, errorRatioQuery is used instead of error_ratio_query. This pull request makes that usage more consistent and updates the variables from snake case to camelcase, and updates the documentation as well.

Following the approval of this PR, the documentation on the website should be changed as well.