### PR TITLE
Add denominator adjusted SLO

### DIFF
--- a/internal/k8sprometheus/spec.go
+++ b/internal/k8sprometheus/spec.go
@@ -119,6 +119,13 @@ func mapSpecToModel(ctx context.Context, defaultWindowPeriod time.Duration, plug
 			}
 		}
 
+		if specSLO.SLI.DenominatorCorrected != nil {
+			slo.SLI.DenominatorCorrected = &prometheus.SLIEvents{
+				ErrorQuery: specSLO.SLI.DenominatorCorrected.ErrorQuery,
+				TotalQuery: specSLO.SLI.DenominatorCorrected.TotalQuery,
+			}
+		}
+
 		if specSLO.SLI.Plugin != nil {
 			plugin, err := pluginsRepo.GetSLIPlugin(ctx, specSLO.SLI.Plugin.ID)
 			if err != nil {

--- a/internal/k8sprometheus/spec.go
+++ b/internal/k8sprometheus/spec.go
@@ -120,9 +120,10 @@ func mapSpecToModel(ctx context.Context, defaultWindowPeriod time.Duration, plug
 		}
 
 		if specSLO.SLI.DenominatorCorrected != nil {
-			slo.SLI.DenominatorCorrected = &prometheus.SLIEvents{
-				ErrorQuery: specSLO.SLI.DenominatorCorrected.ErrorQuery,
-				TotalQuery: specSLO.SLI.DenominatorCorrected.TotalQuery,
+			slo.SLI.DenominatorCorrected = &prometheus.SLIDenominatorCorrectedEvents{
+				ErrorQuery:   specSLO.SLI.DenominatorCorrected.ErrorQuery,
+				SuccessQuery: specSLO.SLI.DenominatorCorrected.SuccessQuery,
+				TotalQuery:   specSLO.SLI.DenominatorCorrected.TotalQuery,
 			}
 		}
 

--- a/internal/prometheus/model.go
+++ b/internal/prometheus/model.go
@@ -16,8 +16,9 @@ import (
 
 // SLI reprensents an SLI with custom error and total expressions.
 type SLI struct {
-	Raw    *SLIRaw
-	Events *SLIEvents
+	Raw                  *SLIRaw
+	Events               *SLIEvents
+	DenominatorCorrected *SLIEvents
 }
 
 type SLIRaw struct {

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -70,6 +70,8 @@ func factorySLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBA
 	// Raw based SLI.
 	case slo.SLI.Raw != nil:
 		return rawSLIRecordGenerator(slo, window, alerts)
+	case slo.SLI.DenominatorCorrected != nil:
+		return denominatorCorrectedSLIRecordGenerator(slo, window, alerts)
 	}
 
 	return nil, fmt.Errorf("invalid SLI type")
@@ -123,6 +125,54 @@ func eventsSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAl
 	var b bytes.Buffer
 	err = tpl.Execute(&b, map[string]string{
 		tplKeyWindow: strWindow,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not render SLI expression template: %w", err)
+	}
+
+	return &rulefmt.Rule{
+		Record: slo.GetSLIErrorMetric(window),
+		Expr:   b.String(),
+		Labels: mergeLabels(
+			slo.GetSLOIDPromLabels(),
+			map[string]string{
+				sloWindowLabelName: strWindow,
+			},
+			slo.Labels,
+		),
+	}, nil
+}
+
+func denominatorCorrectedSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+	const sliExprTplFmt = `(
+slo:numerator_correction:ratio{{.window}}{{.filter}}
+* on()
+%s
+)
+/
+(%s)
+`
+	// 	const sliExprTplFmt = `sum_over_time({{.metric}}{{.filter}}[{{.window}}])
+	// / ignoring ({{.windowKey}})
+	// count_over_time({{.metric}}{{.filter}}[{{.window}}])
+
+	// sloth_id: deployments-velo_expected_errors
+	// sloth_service: deployments
+	// sloth_slo: velo_expected_errors
+	sliExprTpl := fmt.Sprintf(sliExprTplFmt, slo.SLI.DenominatorCorrected.ErrorQuery, slo.SLI.DenominatorCorrected.TotalQuery)
+
+	// Render with our templated data.
+	tpl, err := template.New("sliExpr").Option("missingkey=error").Parse(sliExprTpl)
+	if err != nil {
+		return nil, fmt.Errorf("could not create SLI expression template data: %w", err)
+	}
+
+	strWindow := timeDurationToPromStr(window)
+	var b bytes.Buffer
+	err = tpl.Execute(&b, map[string]string{
+		tplKeyWindow: strWindow,
+		"filter":     labelsToPromFilter(slo.GetSLOIDPromLabels()),
+		"windowKey":  sloWindowLabelName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not render SLI expression template: %w", err)
@@ -302,7 +352,59 @@ func (m metadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx cont
 		},
 	}
 
+	if slo.SLI.DenominatorCorrected != nil {
+		for _, window := range [7]time.Duration{
+			time.Minute * 5,
+			time.Minute * 30,
+			time.Hour,
+			time.Hour * 2,
+			time.Hour * 6,
+			time.Hour * 24,
+			time.Hour * 24 * 3,
+		} {
+			rule, err := createNumeratorCorrection(slo, labels, window)
+			if err != nil {
+				return nil, fmt.Errorf("Could not create numerator rule: %v", err)
+			}
+			rules = append(rules, *rule)
+		}
+	}
+
 	return rules, nil
+}
+
+func createNumeratorCorrection(slo SLO, labels map[string]string, window time.Duration) (*rulefmt.Rule, error) {
+	windowString := timeDurationToPromStr(window)
+	metricSLONumeratorCorrection := fmt.Sprintf("slo:numerator_correction:ratio%s", windowString)
+	totalquery := slo.SLI.DenominatorCorrected.TotalQuery
+
+	tpl, err := template.New("sliExpr").Option("missingkey=error").Parse(totalquery)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %s expression template data: %w", metricSLONumeratorCorrection, err)
+	}
+
+	var numeratorBuffer bytes.Buffer
+	err = tpl.Execute(&numeratorBuffer, map[string]string{
+		tplKeyWindow: windowString,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create numerator for %s: %w", metricSLONumeratorCorrection, err)
+	}
+
+	denominatorWindow := timeDurationToPromStr(time.Hour * 24 * 7)
+	var denominatorBuffer bytes.Buffer
+	err = tpl.Execute(&denominatorBuffer, map[string]string{
+		tplKeyWindow: denominatorWindow,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create denominator for %s: %w", metricSLONumeratorCorrection, err)
+	}
+
+	return &rulefmt.Rule{
+		Record: metricSLONumeratorCorrection,
+		Expr:   fmt.Sprintf(`(%s)/(%s)`, numeratorBuffer.String(), denominatorBuffer.String()),
+		Labels: labels,
+	}, nil
 }
 
 var burnRateRecordingExprTpl = template.Must(template.New("burnRateExpr").Option("missingkey=error").Parse(`{{ .SLIErrorMetric }}{{ .MetricFilter }}

--- a/pkg/kubernetes/api/sloth/v1/types.go
+++ b/pkg/kubernetes/api/sloth/v1/types.go
@@ -94,6 +94,10 @@ type SLI struct {
 	// +optional
 	Events *SLIEvents `json:"events,omitempty"`
 
+	// Events is the events SLI type.
+	// +optional
+	DenominatorCorrected *SLIEvents `json:"denominator_corrected,omitempty"`
+
 	// Plugin is the pluggable SLI type.
 	// +optional
 	Plugin *SLIPlugin `json:"plugin,omitempty"`

--- a/pkg/kubernetes/api/sloth/v1/types.go
+++ b/pkg/kubernetes/api/sloth/v1/types.go
@@ -96,7 +96,7 @@ type SLI struct {
 
 	// Events is the events SLI type.
 	// +optional
-	DenominatorCorrected *SLIEvents `json:"denominator_corrected,omitempty"`
+	DenominatorCorrected *SLIDenominatorCorrected `json:"denominator_corrected,omitempty"`
 
 	// Plugin is the pluggable SLI type.
 	// +optional
@@ -117,6 +117,25 @@ type SLIEvents struct {
 	// that we consider that are bad for the SLO (e.g "http 5xx", "latency > 250ms"...).
 	// Requires the usage of `{{.window}}` template variable.
 	ErrorQuery string `json:"errorQuery"`
+
+	// TotalQuery is a Prometheus query that will get the total number/count of events
+	// for the SLO (e.g "all http requests"...).
+	// Requires the usage of `{{.window}}` template variable.
+	TotalQuery string `json:"totalQuery"`
+}
+
+// SLIDenominatorCorrected is an SLI that is calculated as the division of bad events and total events, or
+// 1 - (good / total) events giving a ratio SLI
+type SLIDenominatorCorrected struct {
+	// ErrorQuery is a Prometheus query that will get the number/count of events
+	// that we consider that are bad for the SLO (e.g "http 5xx", "latency > 250ms"...).
+	// Requires the usage of `{{.window}}` template variable.
+	ErrorQuery *string `json:"errorQuery,omitempty"`
+
+	// ErrorQuery is a Prometheus query that will get the number/count of events
+	// that we consider that are bad for the SLO (e.g "http 5xx", "latency > 250ms"...).
+	// Requires the usage of `{{.window}}` template variable.
+	SuccessQuery *string `json:"successQuery,omitempty"`
 
 	// TotalQuery is a Prometheus query that will get the total number/count of events
 	// for the SLO (e.g "all http requests"...).


### PR DESCRIPTION
Add recording rules for storing how the current number of events compares to the average of the preceding week. This allows an SLO to burn faster or slower depending on whether there are a lot or few events in the denominator.

This will make sure that SLO's burn slower at night when there are fewevents.