### PR TITLE
fixed: wrong math comparator in example

### DIFF
--- a/examples/kubernetes-apiserver.yml
+++ b/examples/kubernetes-apiserver.yml
@@ -11,7 +11,7 @@
 #
 # - `requests-latency`
 #   - This SLO warn us that we apiserver responses are being slow and this will affect the clients  (kubectl users, controllers...).
-#   - SLI error: We consider a bad request (event) when the response latency is <400ms.
+#   - SLI error: We consider a bad request (event) when the response latency is >400ms.
 #   - SLO objective(99%): We have a relaxed objective because Kubernetes has a lot of async and eventual consistency flows. We could
 #                         create in a future another SLO that is less restrictive and use the latency of the realtime requests (e.g: kubectl).
 #


### PR DESCRIPTION
SLI Error wrong "<400ms" condition not matching the formula in the code of sli error_query
See examples/kubernetes-apiserver.yml