### PR TITLE
fix(helm): add nodeSelector, affinity and topologySpreadConstraint to Helm Chart

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.7.0
+version: 0.7.1

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -113,6 +113,23 @@ spec:
       imagePullSecrets:
 {{ include "sloth.imagePullSecrets" . | trim | indent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with.Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
       volumes:
       {{- if .Values.commonPlugins.enabled }}

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -75,3 +75,11 @@ securityContext:
   #   runAsUser: 100
   container: null
   #   allowPrivilegeEscalation: false
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+topologySpreadConstraints: []

--- a/deploy/kubernetes/raw/sloth.yaml
+++ b/deploy/kubernetes/raw/sloth.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.6.4
+    helm.sh/chart: sloth-0.7.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.6.4
+    helm.sh/chart: sloth-0.7.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.6.4
+    helm.sh/chart: sloth-0.7.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -59,7 +59,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.6.4
+    helm.sh/chart: sloth-0.7.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.6.4
+        helm.sh/chart: sloth-0.7.1
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
@@ -107,7 +107,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.6.4
+    helm.sh/chart: sloth-0.7.1
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth


### PR DESCRIPTION
Fixes #475 

Added the following config in Deployment template and to Chart default values.yaml:

- affinity
- nodeSelector
- topologySpreadConstraint

And updated the version in the Chart.yaml and in the raw manifest files.