### PR TITLE
Pull git-sync image from registry.k8s.io

### DIFF
--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -68,7 +68,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: registry.k8s.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.7
           args:
             - --repo=https://github.com/slok/sloth-test-common-sli-plugins
             - --branch=main

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -68,7 +68,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-test-common-sli-plugins
             - --branch=main

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -52,7 +52,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: registry.k8s.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.7
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_default.yaml
@@ -52,7 +52,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -34,7 +34,7 @@ commonPlugins:
   enabled: true
   image:
     repository: registry.k8s.io/git-sync/git-sync
-    tag: v3.6.1
+    tag: v3.6.7
   gitRepo:
     url: https://github.com/slok/sloth-common-sli-plugins
     branch: main

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -33,7 +33,7 @@ sloth:
 commonPlugins:
   enabled: true
   image:
-    repository: k8s.gcr.io/git-sync/git-sync
+    repository: registry.k8s.io/git-sync/git-sync
     tag: v3.6.1
   gitRepo:
     url: https://github.com/slok/sloth-common-sli-plugins

--- a/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
+++ b/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
@@ -104,7 +104,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: k8s.gcr.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.1
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main

--- a/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
+++ b/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
@@ -104,7 +104,7 @@ spec:
               cpu: 5m
               memory: 75Mi
         - name: git-sync-plugins
-          image: registry.k8s.io/git-sync/git-sync:v3.6.1
+          image: registry.k8s.io/git-sync/git-sync:v3.6.7
           args:
             - --repo=https://github.com/slok/sloth-common-sli-plugins
             - --branch=main


### PR DESCRIPTION
Hello,

This is just a PR to change the git-sync registry from k8s.gcr.io to registry.k8s.io as per: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/