### PR TITLE
Add pod affinity and fix pod tollerations

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.7.0
+version: 0.7.1

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -85,11 +85,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-          {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.tolerations }}
-          tolerations:
-{{ toYaml . | trim | indent 12 }}
-          {{- end }}
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.commonPlugins.enabled }}
         - name: git-sync-plugins
           image: {{ .Values.commonPlugins.image.repository }}:{{ .Values.commonPlugins.image.tag }}
@@ -107,11 +103,11 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-          {{- toYaml .Values.commonPlugins.gitRepo.resources | nindent 12 }}
+            {{- toYaml .Values.commonPlugins.gitRepo.resources | nindent 12 }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ include "sloth.imagePullSecrets" . | trim | indent 8 }}
+        {{- include "sloth.imagePullSecrets" . | trim | nindent 8 }}
       {{- end }}
       {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
       volumes:
@@ -126,4 +122,11 @@ spec:
             name: {{ include "sloth.fullname" . }}
       {{- end }}
       {{- end }}
-
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | trim | nindent 8 }}
+      {{- end }}

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -60,12 +60,25 @@ customSloConfig:
 #    spec:
 #    ... See https://sloth.dev/usage/slo-period-windows/
 
-# add deployment pod tolerations
+# Pod affinity
+# affinity:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: kubernetes.io/os
+#           operator: In
+#           values:
+#           - linux
+affinity: {}
+
+# Pod tolerations
 # tolerations:
 #   - key: kubernetes.azure.com/scalesetpriority
 #     operator: Equal
 #     value: spot
 #     effect: NoSchedule
+tollerations: []
 
 securityContext:
   pod: null


### PR DESCRIPTION
This PR introduces a few small changes to Helm chart definitions.

## Added 
- `affinity` definition to `deployment.yaml` and `values.yaml` files

## Fixed
- `tolerations` definition was moved to the pod spec level ([link](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podspec-v1-core))
- minor syntax adjustments in `deployment.yaml`