### PR TITLE
Tolerations fix for deployment template

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.7.0
+version: 0.7.1

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | trim | indent 8 }}
+      {{- end }}
       containers:
         - name: sloth
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -86,10 +90,6 @@ spec:
           {{- end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.tolerations }}
-          tolerations:
-{{ toYaml . | trim | indent 12 }}
-          {{- end }}
         {{- if .Values.commonPlugins.enabled }}
         - name: git-sync-plugins
           image: {{ .Values.commonPlugins.image.repository }}:{{ .Values.commonPlugins.image.tag }}


### PR DESCRIPTION
### Summary

There is an issue with the current deployment template yaml file when setting tolerations in the values.yaml file.

Setting the tolerations in the values.yaml file:
```
tolerations:
  - key: "infra"
     operator: "Equal"
     value: "true"
     effect: "NoSchedule"
```

Error message when deploying:
```
k apply -f sloth4.yaml -n sloth 
...
serviceaccount/sloth created
clusterrole.rbac.authorization.k8s.io/sloth created
clusterrolebinding.rbac.authorization.k8s.io/sloth created
Error from server (BadRequest): error when creating "sloth4.yaml": Deployment in version "v1" cannot be handled as a Deployment: strict decoding error: unknown field "spec.template.spec.containers[0].tolerations"
```

### Fix
This PR fixes the deployment.yaml issue by moving the `tolerations` on the pod spec level. 