### PR TITLE
Allow extra env via helm values

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -69,6 +69,13 @@ spec:
               name: metrics
               protocol: TCP
           {{- end }}
+          {{- if .Values.extraEnv }}
+          env:
+          {{- range $key, $value := .Values.extraEnv }}
+            — name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
+          {{- end}}
           {{- if or .Values.commonPlugins.enabled .Values.customSloConfig.enabled }}
           volumeMounts:
           {{- if .Values.commonPlugins.enabled }}
@@ -98,6 +105,13 @@ spec:
             - --branch={{.Values.commonPlugins.gitRepo.branch}}
             - --wait=30
             - --webhook-url=http://localhost:8082/-/reload
+          {{- if .Values.commonPlugins.extraEnv }}
+          env:
+          {{- range $key, $value := .Values.commonPlugins.extraEnv }}
+            — name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
+          {{- end}}
           volumeMounts:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -16,6 +16,11 @@ func customValues() msi {
 			"repository": "slok/sloth-test",
 			"tag":        "v1.42.42",
 		},
+		
+		"extraEnv": msi{
+			"CUSTOM_ENV": "customValue",
+			"SECOND_ENV": "secondValue",
+		},
 
 		"sloth": msi{
 			"resyncInterval": "17m",
@@ -34,6 +39,10 @@ func customValues() msi {
 			"gitRepo": msi{
 				"url":    "https://github.com/slok/sloth-test-common-sli-plugins",
 				"branch": "main",
+			},
+			"extraEnv": msi{
+				"CUSTOM_PLUGIN_ENV": "customValue",
+				"SECOND_PLUGIN_ENV": "secondValue",
 			},
 		},
 


### PR DESCRIPTION
It has proven to be a very efficient pattern to allow the extension of environment variables via the values file in a helm chart, for example with a values key like `extraEnv`.
This makes the deployment more flexible without introducing another layer of complexity.

Several Projects adopted a similar approach: [Code Search 'extraEnv' in helm/charts](https://github.com/search?q=repo%3Ahelm%2Fcharts+extraEnv&type=code)