### PR TITLE
feat: add extra-filter-labels param

### DIFF
--- a/cmd/sloth/commands/k8scontroller.go
+++ b/cmd/sloth/commands/k8scontroller.go
@@ -53,6 +53,7 @@ const (
 
 type kubeControllerCommand struct {
 	extraLabels           map[string]string
+	extraFilterLabels     map[string]string
 	workers               int
 	kubeConfig            string
 	kubeContext           string
@@ -73,7 +74,10 @@ type kubeControllerCommand struct {
 
 // NewKubeControllerCommand returns the Kubernetes controller command.
 func NewKubeControllerCommand(app *kingpin.Application) Command {
-	c := &kubeControllerCommand{extraLabels: map[string]string{}}
+	c := &kubeControllerCommand{
+		extraLabels:       map[string]string{},
+		extraFilterLabels: map[string]string{},
+	}
 	cmd := app.Command("kubernetes-controller", "Runs Sloth in Kubernetes controller/operator mode.")
 	cmd.Alias("controller")
 	cmd.Alias("k8s-controller")
@@ -92,6 +96,7 @@ func NewKubeControllerCommand(app *kingpin.Application) Command {
 	cmd.Flag("hot-reload-addr", "The listen address for hot-reloading components that allow it.").Default(":8082").StringVar(&c.hotReloadAddr)
 	cmd.Flag("hot-reload-path", "The webhook path for hot-reloading components that allow it.").Default("/-/reload").StringVar(&c.hotReloadPath)
 	cmd.Flag("extra-labels", "Extra labels that will be added to all the generated Prometheus rules ('key=value' form, can be repeated).").Short('l').StringMapVar(&c.extraLabels)
+	cmd.Flag("extra-filter-labels", "Extra labels that will be added to all the generated Prometheus rules, but also will be added as filters to the generated recording rules. Can be used as templates in queries provided by the user. ('key=value' form, can be repeated).").StringMapVar(&c.extraFilterLabels)
 	cmd.Flag("sli-plugins-path", "The path to SLI plugins (can be repeated), if not set it disable plugins support.").Short('p').StringsVar(&c.sliPluginsPaths)
 	cmd.Flag("slo-period-windows-path", "The directory path to custom SLO period windows catalog (replaces default ones).").StringVar(&c.sloPeriodWindowsPath)
 	cmd.Flag("default-slo-period", "The default SLO period windows to be used for the SLOs.").Default("30d").StringVar(&c.sloPeriod)
@@ -318,12 +323,13 @@ func (k kubeControllerCommand) Run(ctx context.Context, config RootConfig) error
 
 		// Create handler.
 		config := kubecontroller.HandlerConfig{
-			Generator:        generator,
-			SpecLoader:       k8sprometheus.NewCRSpecLoader(pluginRepo, sloPeriod),
-			Repository:       k8sprometheus.NewPrometheusOperatorCRDRepo(ksvc, logger),
-			KubeStatusStorer: ksvc,
-			ExtraLabels:      k.extraLabels,
-			Logger:           logger,
+			Generator:         generator,
+			SpecLoader:        k8sprometheus.NewCRSpecLoader(pluginRepo, sloPeriod),
+			Repository:        k8sprometheus.NewPrometheusOperatorCRDRepo(ksvc, logger),
+			KubeStatusStorer:  ksvc,
+			ExtraLabels:       k.extraLabels,
+			ExtraFilterLabels: k.extraFilterLabels,
+			Logger:            logger,
 		}
 		handler, err := kubecontroller.NewHandler(config)
 		if err != nil {

--- a/cmd/sloth/commands/validate.go
+++ b/cmd/sloth/commands/validate.go
@@ -24,6 +24,7 @@ type validateCommand struct {
 	slosExcludeRegex     string
 	slosIncludeRegex     string
 	extraLabels          map[string]string
+	extraFilterLabels    map[string]string
 	sliPluginsPaths      []string
 	sloPeriodWindowsPath string
 	sloPeriod            string
@@ -31,12 +32,16 @@ type validateCommand struct {
 
 // NewValidateCommand returns the validate command.
 func NewValidateCommand(app *kingpin.Application) Command {
-	c := &validateCommand{extraLabels: map[string]string{}}
+	c := &validateCommand{
+		extraLabels:       map[string]string{},
+		extraFilterLabels: map[string]string{},
+	}
 	cmd := app.Command("validate", "Validates the SLO manifests and generation of Prometheus SLOs.")
 	cmd.Flag("input", "SLO spec discovery path, will discover recursively all YAML files.").Short('i').Required().StringVar(&c.slosInput)
 	cmd.Flag("fs-exclude", "Filter regex to ignore matched discovered SLO file paths.").Short('e').StringVar(&c.slosExcludeRegex)
 	cmd.Flag("fs-include", "Filter regex to include matched discovered SLO file paths, everything else will be ignored. Exclude has preference.").Short('n').StringVar(&c.slosIncludeRegex)
 	cmd.Flag("extra-labels", "Extra labels that will be added to all the generated Prometheus rules ('key=value' form, can be repeated).").Short('l').StringMapVar(&c.extraLabels)
+	cmd.Flag("extra-filter-labels", "Extra labels that will be added to all the generated Prometheus rules, but also will be added as filters to the generated recording rules. Can be used as templates in queries provided by the user. ('key=value' form, can be repeated).").StringMapVar(&c.extraFilterLabels)
 	cmd.Flag("sli-plugins-path", "The path to SLI plugins (can be repeated), if not set it disable plugins support.").Short('p').StringsVar(&c.sliPluginsPaths)
 	cmd.Flag("slo-period-windows-path", "The directory path to custom SLO period windows catalog (replaces default ones).").StringVar(&c.sloPeriodWindowsPath)
 	cmd.Flag("default-slo-period", "The default SLO period windows to be used for the SLOs.").Default("30d").StringVar(&c.sloPeriod)
@@ -126,9 +131,10 @@ func (v validateCommand) Run(ctx context.Context, config RootConfig) error {
 		splittedSLOsData := splitYAML(slxData)
 
 		gen := generator{
-			logger:      log.Noop,
-			windowsRepo: windowsRepo,
-			extraLabels: v.extraLabels,
+			logger:            log.Noop,
+			windowsRepo:       windowsRepo,
+			extraLabels:       v.extraLabels,
+			extraFilterLabels: v.extraFilterLabels,
 		}
 
 		// Prepare file validation result and start validation result for every SLO in the file.

--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             {{- range $key, $val := .Values.sloth.extraLabels }}
             - --extra-labels={{ $key }}={{ $val }}
             {{- end}}
+            {{- range $key, $val := .Values.sloth.extraFilterLabels }}
+            - --extra-filter-labels={{ $key }}={{ $val }}
+            {{- end}}
             {{- if .Values.commonPlugins.enabled }}
             - --sli-plugins-path=/plugins
             {{- end }}

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -27,6 +27,10 @@ func customValues() msi {
 				"k1": "v1",
 				"k2": "v2",
 			},
+			"extraFilterLabels": msi{
+				"k3": "v3",
+				"k4": "v4",
+			},
 		},
 
 		"commonPlugins": msi{

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -23,6 +23,7 @@ sloth:
   labelSelector: ""     # Sloth will handle only the ones that match the selector.
   namespace: ""         # The namespace where sloth will the CRs to process.
   extraLabels: {}       # Labels that will be added to all the generated SLO Rules.
+  extraFilterLabels: {} # Labels that will be added to all the generated SLO Rules, but also will be added as filters to the generated recording rules. Can be used as templates in queries provided by the user.
   defaultSloPeriod: ""  # The slo period used by sloth (e.g. 30d).
   optimizedRules: true  # Reduce prom load for calculating period window burnrates.
   debug:

--- a/internal/app/generate/noop.go
+++ b/internal/app/generate/noop.go
@@ -13,7 +13,7 @@ type noopSLIRecordingRulesGenerator bool
 
 const NoopSLIRecordingRulesGenerator = noopSLIRecordingRulesGenerator(false)
 
-func (noopSLIRecordingRulesGenerator) GenerateSLIRecordingRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (noopSLIRecordingRulesGenerator) GenerateSLIRecordingRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup, extraFilterLabels map[string]string) ([]rulefmt.Rule, error) {
 	return nil, nil
 }
 
@@ -21,7 +21,7 @@ type noopMetadataRecordingRulesGenerator bool
 
 const NoopMetadataRecordingRulesGenerator = noopMetadataRecordingRulesGenerator(false)
 
-func (noopMetadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx context.Context, info info.Info, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (noopMetadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx context.Context, info info.Info, slo prometheus.SLO, alerts alert.MWMBAlertGroup, extraFilterLabels map[string]string) ([]rulefmt.Rule, error) {
 	return nil, nil
 }
 

--- a/internal/prometheus/recording_rules_test.go
+++ b/internal/prometheus/recording_rules_test.go
@@ -36,7 +36,7 @@ func getAlertGroup() alert.MWMBAlertGroup {
 
 func TestGenerateSLIRecordingRules(t *testing.T) {
 	type generator interface {
-		GenerateSLIRecordingRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error)
+		GenerateSLIRecordingRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup, extraFilterLabels map[string]string) ([]rulefmt.Rule, error)
 	}
 
 	tests := map[string]struct {
@@ -493,7 +493,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			gotRules, err := test.generator().GenerateSLIRecordingRules(context.TODO(), test.slo, test.alertGroup)
+			gotRules, err := test.generator().GenerateSLIRecordingRules(context.TODO(), test.slo, test.alertGroup, map[string]string{})
 
 			if test.expErr {
 				assert.Error(err)
@@ -618,7 +618,7 @@ slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="tes
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			gotRules, err := prometheus.MetadataRecordingRulesGenerator.GenerateMetadataRecordingRules(context.TODO(), test.info, test.slo, test.alertGroup)
+			gotRules, err := prometheus.MetadataRecordingRulesGenerator.GenerateMetadataRecordingRules(context.TODO(), test.info, test.slo, test.alertGroup, map[string]string{})
 
 			if test.expErr {
 				assert.Error(err)


### PR DESCRIPTION
## Motivation and use cases
This param is mostly useful when using Sloth with a metric storage for multiple k8s clusters (like VictoriaMetrics).

Even if you would define a unique name for each SLO and provide a proper filter in each query, some of the generated rules would end up without the required filter and you would result in an error when executing the generated rules: `result contains metrics with the same labelset after applying rule labels`

Assuming you define `--extra-filter-labels cluster=my-cluster-name` for Sloth operator,
It allows for using the same SLO names on each cluster as `{{ .cluster }}` can be referenced in the user's query and also will be used as filter in the created recording rules, which users can't modify, fixing previously described problem.  The `cluster` label will be also added to the resulting metrics in similar fasion to `--extra-labels`, so it ensures that the resulting metrics can be differentiated.

This fixes issues like #430 or can be helpful for #349


