### PR TITLE
Allow spec files with CRLF

### DIFF
--- a/internal/prometheus/spec.go
+++ b/internal/prometheus/spec.go
@@ -30,7 +30,7 @@ func NewYAMLSpecLoader(pluginsRepo SLIPluginRepo, windowPeriod time.Duration) YA
 	}
 }
 
-var specTypeV1Regex = regexp.MustCompile(`(?m)^version: +['"]?prometheus\/v1['"]? *$`)
+var specTypeV1Regex = regexp.MustCompile(`(?m)^version: +['"]?prometheus/v1['"]?\r?\n? *$`)
 
 func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
 	return specTypeV1Regex.Match(data)


### PR DESCRIPTION
When we use config files that has line ending with CRLF the sloth fails to recognise specs because of the regex rules.

This change allows sloth to recognize prometheus spec in CRLF files.

Fixes: https://github.com/slok/sloth/issues/406