### PR TITLE
Add a middle domain model for prom rules

### DIFF
--- a/internal/app/generate/prometheus.go
+++ b/internal/app/generate/prometheus.go
@@ -98,13 +98,13 @@ type Request struct {
 	// ExtraLabels are the extra labels added to the SLOs on execution time.
 	ExtraLabels map[string]string
 	// SLOGroup are the SLOs group that will be used to generate the SLO results and Prom rules.
-	SLOGroup prometheus.SLOGroup
+	SLOGroup model.PromSLOGroup
 }
 
 type SLOResult struct {
-	SLO      prometheus.SLO
+	SLO      model.PromSLO
 	Alerts   model.MWMBAlertGroup
-	SLORules prometheus.SLORules
+	SLORules model.PromSLORules
 }
 
 type Response struct {
@@ -176,10 +176,10 @@ func (s Service) generateSLO(ctx context.Context, info model.Info, slo prometheu
 	return &SLOResult{
 		SLO:    slo,
 		Alerts: *as,
-		SLORules: prometheus.SLORules{
-			SLIErrorRecRules: sliRecordingRules,
-			MetadataRecRules: metaRecordingRules,
-			AlertRules:       alertRules,
+		SLORules: model.PromSLORules{
+			SLIErrorRecRules: model.PromRuleGroup{Rules: sliRecordingRules},
+			MetadataRecRules: model.PromRuleGroup{Rules: metaRecordingRules},
+			AlertRules:       model.PromRuleGroup{Rules: alertRules},
 		},
 	}, nil
 }

--- a/internal/app/generate/prometheus_test.go
+++ b/internal/app/generate/prometheus_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/slok/sloth/internal/alert"
 	"github.com/slok/sloth/internal/app/generate"
-	"github.com/slok/sloth/internal/prometheus"
 	"github.com/slok/sloth/pkg/common/model"
 )
 
@@ -37,13 +36,13 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 					Mode:    model.ModeTest,
 					Spec:    "test-spec",
 				},
-				SLOGroup: prometheus.SLOGroup{SLOs: []prometheus.SLO{
+				SLOGroup: model.PromSLOGroup{SLOs: []model.PromSLO{
 					{
 						ID:      "test-id",
 						Name:    "test-name",
 						Service: "test-svc",
-						SLI: prometheus.SLI{
-							Events: &prometheus.SLIEvents{
+						SLI: model.PromSLI{
+							Events: &model.PromSLIEvents{
 								ErrorQuery: `rate(my_metric{error="true"}[{{.window}}])`,
 								TotalQuery: `rate(my_metric[{{.window}}])`,
 							},
@@ -51,29 +50,28 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 						TimeWindow: 30 * 24 * time.Hour,
 						Objective:  99.9,
 						Labels:     map[string]string{"test_label": "label_1"},
-						PageAlertMeta: prometheus.AlertMeta{
+						PageAlertMeta: model.PromAlertMeta{
 							Name:        "p_alert_test_name",
 							Labels:      map[string]string{"p_alert_label": "p_label_al_1"},
 							Annotations: map[string]string{"p_alert_annot": "p_label_an_1"},
 						},
-						TicketAlertMeta: prometheus.AlertMeta{
+						TicketAlertMeta: model.PromAlertMeta{
 							Name:        "t_alert_test_name",
 							Labels:      map[string]string{"t_alert_label": "t_label_al_1"},
 							Annotations: map[string]string{"t_alert_annot": "t_label_an_1"},
 						},
 					},
-				},
-				},
+				}},
 			},
 			expResp: generate.Response{
 				PrometheusSLOs: []generate.SLOResult{
 					{
-						SLO: prometheus.SLO{
+						SLO: model.PromSLO{
 							ID:      "test-id",
 							Name:    "test-name",
 							Service: "test-svc",
-							SLI: prometheus.SLI{
-								Events: &prometheus.SLIEvents{
+							SLI: model.PromSLI{
+								Events: &model.PromSLIEvents{
 									ErrorQuery: `rate(my_metric{error="true"}[{{.window}}])`,
 									TotalQuery: `rate(my_metric[{{.window}}])`,
 								},
@@ -85,12 +83,12 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								"extra_k1":   "extra_v1",
 								"extra_k2":   "extra_v2",
 							},
-							PageAlertMeta: prometheus.AlertMeta{
+							PageAlertMeta: model.PromAlertMeta{
 								Name:        "p_alert_test_name",
 								Labels:      map[string]string{"p_alert_label": "p_label_al_1"},
 								Annotations: map[string]string{"p_alert_annot": "p_label_an_1"},
 							},
-							TicketAlertMeta: prometheus.AlertMeta{
+							TicketAlertMeta: model.PromAlertMeta{
 								Name:        "t_alert_test_name",
 								Labels:      map[string]string{"t_alert_label": "t_label_al_1"},
 								Annotations: map[string]string{"t_alert_annot": "t_label_an_1"},
@@ -131,8 +129,8 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								Severity:       model.TicketAlertSeverity,
 							},
 						},
-						SLORules: prometheus.SLORules{
-							SLIErrorRecRules: []rulefmt.Rule{
+						SLORules: model.PromSLORules{
+							SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 								{
 									Record: "slo:sli_error:ratio_rate5m",
 									Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
@@ -237,8 +235,8 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 										"sloth_window":  "30d",
 									},
 								},
-							},
-							MetadataRecRules: []rulefmt.Rule{
+							}},
+							MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 								// Metadata labels.
 								{
 									Record: "slo:objective:ratio",
@@ -334,8 +332,8 @@ slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="
 										"sloth_objective": "99.9",
 									},
 								},
-							},
-							AlertRules: []rulefmt.Rule{
+							}},
+							AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 
 								{
 									Alert: "p_alert_test_name",
@@ -385,7 +383,7 @@ or
 										"title":         "(ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget burn rate is too fast.",
 									},
 								},
-							},
+							}},
 						},
 					},
 				},

--- a/internal/k8sprometheus/storage.go
+++ b/internal/k8sprometheus/storage.go
@@ -106,24 +106,24 @@ func mapModelToPrometheusOperator(ctx context.Context, kmeta K8sMeta, slos []Sto
 	}
 
 	for _, slo := range slos {
-		if len(slo.Rules.SLIErrorRecRules) > 0 {
+		if len(slo.Rules.SLIErrorRecRules.Rules) > 0 {
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Name:  fmt.Sprintf("sloth-slo-sli-recordings-%s", slo.SLO.ID),
-				Rules: promRulesToKubeRules(slo.Rules.SLIErrorRecRules),
+				Rules: promRulesToKubeRules(slo.Rules.SLIErrorRecRules.Rules),
 			})
 		}
 
-		if len(slo.Rules.MetadataRecRules) > 0 {
+		if len(slo.Rules.MetadataRecRules.Rules) > 0 {
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Name:  fmt.Sprintf("sloth-slo-meta-recordings-%s", slo.SLO.ID),
-				Rules: promRulesToKubeRules(slo.Rules.MetadataRecRules),
+				Rules: promRulesToKubeRules(slo.Rules.MetadataRecRules.Rules),
 			})
 		}
 
-		if len(slo.Rules.AlertRules) > 0 {
+		if len(slo.Rules.AlertRules.Rules) > 0 {
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Name:  fmt.Sprintf("sloth-slo-alerts-%s", slo.SLO.ID),
-				Rules: promRulesToKubeRules(slo.Rules.AlertRules),
+				Rules: promRulesToKubeRules(slo.Rules.AlertRules.Rules),
 			})
 		}
 	}

--- a/internal/k8sprometheus/storage_test.go
+++ b/internal/k8sprometheus/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/slok/sloth/internal/k8sprometheus/k8sprometheusmock"
 	"github.com/slok/sloth/internal/log"
 	"github.com/slok/sloth/internal/prometheus"
+	"github.com/slok/sloth/pkg/common/model"
 )
 
 func TestIOWriterPrometheusOperatorYAMLRepo(t *testing.T) {
@@ -52,13 +53,13 @@ func TestIOWriterPrometheusOperatorYAMLRepo(t *testing.T) {
 				{
 					SLO: prometheus.SLO{ID: "test1"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record",
 								Expr:   "test-expr",
 								Labels: map[string]string{"test-label": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -101,13 +102,13 @@ spec:
 				{
 					SLO: prometheus.SLO{ID: "test1"},
 					Rules: prometheus.SLORules{
-						MetadataRecRules: []rulefmt.Rule{
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record",
 								Expr:   "test-expr",
 								Labels: map[string]string{"test-label": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -150,14 +151,14 @@ spec:
 				{
 					SLO: prometheus.SLO{ID: "test1"},
 					Rules: prometheus.SLORules{
-						AlertRules: []rulefmt.Rule{
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlert",
 								Expr:        "test-expr",
 								Labels:      map[string]string{"test-label": "one"},
 								Annotations: map[string]string{"test-annot": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -203,7 +204,7 @@ spec:
 				{
 					SLO: prometheus.SLO{ID: "testa"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a1",
 								Expr:   "test-expr-a1",
@@ -214,8 +215,8 @@ spec:
 								Expr:   "test-expr-a2",
 								Labels: map[string]string{"test-label": "a-2"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a3",
 								Expr:   "test-expr-a3",
@@ -226,8 +227,8 @@ spec:
 								Expr:   "test-expr-a4",
 								Labels: map[string]string{"test-label": "a-4"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertA1",
 								Expr:        "test-expr-a1",
@@ -240,34 +241,34 @@ spec:
 								Labels:      map[string]string{"test-label": "a-2"},
 								Annotations: map[string]string{"test-annot": "a-2"},
 							},
-						},
+						}},
 					},
 				},
 				{
 					SLO: prometheus.SLO{ID: "testb"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b1",
 								Expr:   "test-expr-b1",
 								Labels: map[string]string{"test-label": "b-1"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b2",
 								Expr:   "test-expr-b2",
 								Labels: map[string]string{"test-label": "b-2"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertB1",
 								Expr:        "test-expr-b1",
 								Labels:      map[string]string{"test-label": "b-1"},
 								Annotations: map[string]string{"test-annot": "b-1"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -394,9 +395,9 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 				{
 					SLO: prometheus.SLO{ID: "testa"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{Record: "test:record-a1"},
-						},
+						}},
 					},
 				},
 			},
@@ -420,7 +421,7 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 				{
 					SLO: prometheus.SLO{ID: "testa"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a1",
 								Expr:   "test-expr-a1",
@@ -431,8 +432,8 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 								Expr:   "test-expr-a2",
 								Labels: map[string]string{"test-label": "a-2"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a3",
 								Expr:   "test-expr-a3",
@@ -443,8 +444,8 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 								Expr:   "test-expr-a4",
 								Labels: map[string]string{"test-label": "a-4"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertA1",
 								Expr:        "test-expr-a1",
@@ -457,34 +458,34 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 								Labels:      map[string]string{"test-label": "a-2"},
 								Annotations: map[string]string{"test-annot": "a-2"},
 							},
-						},
+						}},
 					},
 				},
 				{
 					SLO: prometheus.SLO{ID: "testb"},
 					Rules: prometheus.SLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b1",
 								Expr:   "test-expr-b1",
 								Labels: map[string]string{"test-label": "b-1"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b2",
 								Expr:   "test-expr-b2",
 								Labels: map[string]string{"test-label": "b-2"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertB1",
 								Expr:        "test-expr-b1",
 								Labels:      map[string]string{"test-label": "b-1"},
 								Annotations: map[string]string{"test-annot": "b-1"},
 							},
-						},
+						}},
 					},
 				},
 			},

--- a/internal/storage/io/std_prometheus.go
+++ b/internal/storage/io/std_prometheus.go
@@ -48,24 +48,24 @@ func (r StdPrometheusGroupedRulesYAMLRepo) StoreSLOs(ctx context.Context, slos [
 
 	ruleGroups := stdPromRuleGroupsYAMLv2{}
 	for _, slo := range slos {
-		if len(slo.Rules.SLIErrorRecRules) > 0 {
+		if len(slo.Rules.SLIErrorRecRules.Rules) > 0 {
 			ruleGroups.Groups = append(ruleGroups.Groups, stdPromRuleGroupYAMLv2{
 				Name:  fmt.Sprintf("sloth-slo-sli-recordings-%s", slo.SLO.ID),
-				Rules: slo.Rules.SLIErrorRecRules,
+				Rules: slo.Rules.SLIErrorRecRules.Rules,
 			})
 		}
 
-		if len(slo.Rules.MetadataRecRules) > 0 {
+		if len(slo.Rules.MetadataRecRules.Rules) > 0 {
 			ruleGroups.Groups = append(ruleGroups.Groups, stdPromRuleGroupYAMLv2{
 				Name:  fmt.Sprintf("sloth-slo-meta-recordings-%s", slo.SLO.ID),
-				Rules: slo.Rules.MetadataRecRules,
+				Rules: slo.Rules.MetadataRecRules.Rules,
 			})
 		}
 
-		if len(slo.Rules.AlertRules) > 0 {
+		if len(slo.Rules.AlertRules.Rules) > 0 {
 			ruleGroups.Groups = append(ruleGroups.Groups, stdPromRuleGroupYAMLv2{
 				Name:  fmt.Sprintf("sloth-slo-alerts-%s", slo.SLO.ID),
-				Rules: slo.Rules.AlertRules,
+				Rules: slo.Rules.AlertRules.Rules,
 			})
 		}
 	}

--- a/internal/storage/io/std_prometheus_test.go
+++ b/internal/storage/io/std_prometheus_test.go
@@ -36,13 +36,13 @@ func TestGroupedRulesYAMLRepoStore(t *testing.T) {
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record",
 								Expr:   "test-expr",
 								Labels: map[string]string{"test-label": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -65,13 +65,13 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						MetadataRecRules: []rulefmt.Rule{
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record",
 								Expr:   "test-expr",
 								Labels: map[string]string{"test-label": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -94,14 +94,14 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						AlertRules: []rulefmt.Rule{
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlert",
 								Expr:        "test-expr",
 								Labels:      map[string]string{"test-label": "one"},
 								Annotations: map[string]string{"test-annot": "one"},
 							},
-						},
+						}},
 					},
 				},
 			},
@@ -127,7 +127,7 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "testa"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a1",
 								Expr:   "test-expr-a1",
@@ -138,8 +138,8 @@ groups:
 								Expr:   "test-expr-a2",
 								Labels: map[string]string{"test-label": "a-2"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-a3",
 								Expr:   "test-expr-a3",
@@ -150,8 +150,8 @@ groups:
 								Expr:   "test-expr-a4",
 								Labels: map[string]string{"test-label": "a-4"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertA1",
 								Expr:        "test-expr-a1",
@@ -164,34 +164,34 @@ groups:
 								Labels:      map[string]string{"test-label": "a-2"},
 								Annotations: map[string]string{"test-annot": "a-2"},
 							},
-						},
+						}},
 					},
 				},
 				{
 					SLO: model.PromSLO{ID: "testb"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b1",
 								Expr:   "test-expr-b1",
 								Labels: map[string]string{"test-label": "b-1"},
 							},
-						},
-						MetadataRecRules: []rulefmt.Rule{
+						}},
+						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Record: "test:record-b2",
 								Expr:   "test-expr-b2",
 								Labels: map[string]string{"test-label": "b-2"},
 							},
-						},
-						AlertRules: []rulefmt.Rule{
+						}},
+						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
 							{
 								Alert:       "testAlertB1",
 								Expr:        "test-expr-b1",
 								Labels:      map[string]string{"test-label": "b-1"},
 								Annotations: map[string]string{"test-annot": "b-1"},
 							},
-						},
+						}},
 					},
 				},
 			},

--- a/pkg/common/model/slo_prometheus.go
+++ b/pkg/common/model/slo_prometheus.go
@@ -282,7 +282,12 @@ func validateSLOGroup(sl validator.StructLevel) {
 
 // PromSLORules are the prometheus rules required by an SLO.
 type PromSLORules struct {
-	SLIErrorRecRules []rulefmt.Rule
-	MetadataRecRules []rulefmt.Rule
-	AlertRules       []rulefmt.Rule
+	SLIErrorRecRules PromRuleGroup
+	MetadataRecRules PromRuleGroup
+	AlertRules       PromRuleGroup
+}
+
+// PromRuleGroup are regular prometheus group of rules.
+type PromRuleGroup struct {
+	Rules []rulefmt.Rule
 }


### PR DESCRIPTION
This will allow us being more flexible when adding features to final rule groups (e.g: intervals, overrides...).

Related to OSS-23