### PR TITLE
feat: query-dialect support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 )
 
 require (
+	github.com/VictoriaMetrics/metrics v1.34.0 // indirect
+	github.com/VictoriaMetrics/metricsql v0.84.3 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -63,6 +65,8 @@ require (
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.3.3 h1:H5xDQaE3Xow
 github.com/AzureAD/microsoft-authentication-library-for-go v1.3.3/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/OpenSLO/oslo v0.12.0 h1:0zdxMgFE59TUKpe/L4+5ujgmJZW/kAuCOJbyqrTX4lc=
 github.com/OpenSLO/oslo v0.12.0/go.mod h1:6jyOTkqBCdkgqLXJ6WtJj7+o0rSexl6YZbWwnxpGwtU=
+github.com/VictoriaMetrics/metrics v1.34.0 h1:0i8k/gdOJdSoZB4Z9pikVnVQXfhcIvnG7M7h2WaQW2w=
+github.com/VictoriaMetrics/metrics v1.34.0/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
+github.com/VictoriaMetrics/metricsql v0.84.3 h1:MXYiNHpIIzaM49Q/5YhWzcSlFWqLAkjWKOgMlI2NDN8=
+github.com/VictoriaMetrics/metricsql v0.84.3/go.mod h1:1g4hdCwlbJZ851PU9VN65xy9Rdlzupo6fx3SNZ8Z64U=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
@@ -181,6 +185,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/traefik/yaegi v0.16.1 h1:f1De3DVJqIDKmnasUF6MwmWv1dSEEat0wcpXhD2On3E=
 github.com/traefik/yaegi v0.16.1/go.mod h1:4eVhbPb3LnD2VigQjhYbEJ69vDRFdT2HQNrXx8eEwUY=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
+github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
@@ -227,6 +235,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=

--- a/internal/app/generate/generate.go
+++ b/internal/app/generate/generate.go
@@ -44,6 +44,7 @@ type ServiceConfig struct {
 	MetadataRulesGenSLOPlugin SLOProcessor
 	ValidateSLOPlugin         SLOProcessor
 	SLOPluginGetter           SLOPluginGetter
+	QueryValidator            model.QueryValidator
 	Logger                    log.Logger
 }
 
@@ -121,6 +122,7 @@ type Service struct {
 	alertGen        AlertGenerator
 	sloPluginGetter SLOPluginGetter
 	defaultPlugins  []SLOProcessor
+	queryValidator  model.QueryValidator
 	logger          log.Logger
 }
 
@@ -140,7 +142,8 @@ func NewService(config ServiceConfig) (*Service, error) {
 			config.AlertRulesGenSLOPlugin,
 			config.MetadataRulesGenSLOPlugin,
 		},
-		logger: config.Logger,
+		queryValidator: config.QueryValidator,
+		logger:         config.Logger,
 	}, nil
 }
 

--- a/internal/app/generate/generate_test.go
+++ b/internal/app/generate/generate_test.go
@@ -816,10 +816,13 @@ or
 
 			windowsRepo, err := alert.NewFSWindowsRepo(alert.FSWindowsRepoConfig{})
 			require.NoError(err)
+			var queryValidator model.QueryValidator
+			queryValidator.MetricsQL = true
 
 			svc, err := generate.NewService(generate.ServiceConfig{
 				AlertGenerator:  alert.NewGenerator(windowsRepo),
 				SLOPluginGetter: mspg,
+				QueryValidator:  queryValidator,
 			})
 			require.NoError(err)
 

--- a/internal/app/generate/process.go
+++ b/internal/app/generate/process.go
@@ -40,7 +40,9 @@ func NewSLOProcessorFromSLOPluginV1(pluginFactory pluginslov1.PluginFactory, log
 		return nil, fmt.Errorf("could not marshal config: %w", err)
 	}
 
-	plugin, err := pluginFactory(configData, pluginslov1.AppUtils{Logger: logger})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true // FIXME: pass from config
+	plugin, err := pluginFactory(configData, pluginslov1.AppUtils{Logger: logger, QueryValidator: queryValidator})
 	if err != nil {
 		return nil, fmt.Errorf("could not create plugin: %w", err)
 	}

--- a/internal/plugin/slo/core/alert_rules_v1/plugin.go
+++ b/internal/plugin/slo/core/alert_rules_v1/plugin.go
@@ -21,11 +21,15 @@ const (
 	PluginID      = "sloth.dev/core/alert_rules/v1"
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return plugin{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return plugin{
+		appUtils: appUtils,
+	}, nil
 }
 
-type plugin struct{}
+type plugin struct {
+	appUtils pluginslov1.AppUtils
+}
 
 func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	rules, err := p.generateSLOAlertRules(ctx, request.SLO, request.MWMBAlertGroup)

--- a/internal/plugin/slo/core/alert_rules_v1/plugin_test.go
+++ b/internal/plugin/slo/core/alert_rules_v1/plugin_test.go
@@ -263,7 +263,12 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
-	plugin, err := plugin.NewPlugin(nil, pluginslov1.AppUtils{})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+	plugin, err := plugin.NewPlugin(
+		nil,
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/plugin/slo/core/debug_v1/plugin_test.go
+++ b/internal/plugin/slo/core/debug_v1/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	plugin "github.com/slok/sloth/internal/plugin/slo/core/debug_v1"
+	"github.com/slok/sloth/pkg/common/model"
 	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
 	pluginslov1testing "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1/testing"
 )
@@ -60,7 +61,12 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
-	plugin, err := plugin.NewPlugin([]byte(`{}`), pluginslov1.AppUtils{})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+	plugin, err := plugin.NewPlugin(
+		[]byte(`{}`),
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/plugin/slo/core/metadata_rules_v1/plugin.go
+++ b/internal/plugin/slo/core/metadata_rules_v1/plugin.go
@@ -21,11 +21,15 @@ const (
 	PluginID      = "sloth.dev/core/metadata_rules/v1"
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return plugin{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return plugin{
+		appUtils: appUtils,
+	}, nil
 }
 
-type plugin struct{}
+type plugin struct {
+	appUtils pluginslov1.AppUtils
+}
 
 func (plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	metadataRules, err := generateMetadataRecordingRules(ctx, request.Info, request.SLO, request.MWMBAlertGroup)

--- a/internal/plugin/slo/core/metadata_rules_v1/plugin_test.go
+++ b/internal/plugin/slo/core/metadata_rules_v1/plugin_test.go
@@ -201,7 +201,12 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
-	plugin, err := plugin.NewPlugin(nil, pluginslov1.AppUtils{})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+	plugin, err := plugin.NewPlugin(
+		nil,
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/plugin/slo/core/noop_v1/plugin.go
+++ b/internal/plugin/slo/core/noop_v1/plugin.go
@@ -12,11 +12,15 @@ const (
 	PluginID      = "sloth.dev/core/noop/v1"
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return plugin{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return plugin{
+		appUtils: appUtils,
+	}, nil
 }
 
-type plugin struct{}
+type plugin struct {
+	appUtils pluginslov1.AppUtils
+}
 
 func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	return nil

--- a/internal/plugin/slo/core/noop_v1/plugin_test.go
+++ b/internal/plugin/slo/core/noop_v1/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	plugin "github.com/slok/sloth/internal/plugin/slo/core/noop_v1"
+	"github.com/slok/sloth/pkg/common/model"
 	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
 	pluginslov1testing "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1/testing"
 )
@@ -60,7 +61,12 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
-	plugin, err := plugin.NewPlugin(nil, pluginslov1.AppUtils{})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+	plugin, err := plugin.NewPlugin(
+		nil,
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/plugin/slo/core/sli_rules_v1/plugin.go
+++ b/internal/plugin/slo/core/sli_rules_v1/plugin.go
@@ -26,18 +26,22 @@ type PluginConfig struct {
 	Optimized bool
 }
 
-func NewPlugin(c json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+func NewPlugin(c json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
 	cfg := &PluginConfig{}
 	err := json.Unmarshal(c, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	return plugin{cfg: *cfg}, nil
+	return plugin{
+		cfg:      *cfg,
+		appUtils: appUtils,
+	}, nil
 }
 
 type plugin struct {
-	cfg PluginConfig
+	cfg      PluginConfig
+	appUtils pluginslov1.AppUtils
 }
 
 func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {

--- a/internal/plugin/slo/core/sli_rules_v1/plugin_test.go
+++ b/internal/plugin/slo/core/sli_rules_v1/plugin_test.go
@@ -541,8 +541,13 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
 	config, _ := json.Marshal(map[string]any{"optimized": true})
-	plugin, err := plugin.NewPlugin(config, pluginslov1.AppUtils{})
+	plugin, err := plugin.NewPlugin(
+		config,
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/plugin/slo/core/validate_v1/plugin.go
+++ b/internal/plugin/slo/core/validate_v1/plugin.go
@@ -25,7 +25,7 @@ type plugin struct {
 
 func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	// TODO(slok): Should we stop using validator libraries and just use our own simple validation logic created here?
-	err := request.SLO.Validate()
+	err := request.SLO.Validate(p.appUtils.QueryValidator)
 	if err != nil {
 		return fmt.Errorf("invalid slo %q: %w", request.SLO.ID, err)
 	}

--- a/internal/plugin/slo/core/validate_v1/plugin_test.go
+++ b/internal/plugin/slo/core/validate_v1/plugin_test.go
@@ -104,7 +104,10 @@ func TestPlugin(t *testing.T) {
 }
 
 func BenchmarkPluginYaegi(b *testing.B) {
-	plugin, err := pluginslov1testing.NewTestPlugin(b.Context(), pluginslov1testing.TestPluginConfig{PluginConfiguration: []byte(`{}`)})
+	plugin, err := pluginslov1testing.NewTestPlugin(
+		b.Context(),
+		pluginslov1testing.TestPluginConfig{PluginConfiguration: []byte(`{}`)},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -119,7 +122,12 @@ func BenchmarkPluginYaegi(b *testing.B) {
 }
 
 func BenchmarkPluginGo(b *testing.B) {
-	plugin, err := plugin.NewPlugin([]byte(`{}`), pluginslov1.AppUtils{})
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+	plugin, err := plugin.NewPlugin(
+		[]byte(`{}`),
+		pluginslov1.AppUtils{QueryValidator: queryValidator},
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/pluginengine/slo/slo_test.go
+++ b/internal/pluginengine/slo/slo_test.go
@@ -45,11 +45,15 @@ const (
 	PluginID      = "sloth.dev/noop/v1"
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return noopPlugin{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return noopPlugin{
+		appUtils: appUtils,
+	}, nil
 }
 
-type noopPlugin struct{}
+type noopPlugin struct{
+	appUtils pluginslov1.AppUtils
+}
 
 func (noopPlugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	return nil
@@ -73,8 +77,10 @@ const (
 	PluginID      = ""
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return noopPlugin{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return noopPlugin{
+		appUtils: appUtils,
+	}, nil
 }
 
 type noopPlugin struct{}
@@ -101,8 +107,10 @@ const (
 	PluginID      = "sloth.dev/noop/v1"
 )
 
-func NewPlugin2(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return noopPlugin{}, nil
+func NewPlugin2(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return noopPlugin{
+		appUtils: appUtils,
+	}, nil
 }
 
 type noopPlugin struct{}
@@ -131,11 +139,15 @@ const (
 	PluginID      = "sloth.dev/test/v1"
 )
 
-func NewPlugin(_ json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
-	return test{}, nil
+func NewPlugin(_ json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	return test{
+		appUtils: appUtils,
+	}, nil
 }
 
-type test struct{}
+type test struct{
+	appUtils pluginslov1.AppUtils
+}
 
 func (test) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
 	result.SLORules.MetadataRecRules.Rules = []rulefmt.Rule{
@@ -147,7 +159,9 @@ func (test) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result
 }
 `,
 			execPlugin: func(t *testing.T, p pluginengineslo.Plugin) {
-				plugin, err := p.PluginV1Factory(nil, pluginslov1.AppUtils{Logger: log.Noop})
+				var queryValidator model.QueryValidator
+				queryValidator.MetricsQL = true
+				plugin, err := p.PluginV1Factory(nil, pluginslov1.AppUtils{Logger: log.Noop, QueryValidator: queryValidator})
 				require.NoError(t, err)
 				gotResp := &pluginslov1.Result{}
 				err = plugin.ProcessSLO(t.Context(), &pluginslov1.Request{}, gotResp)

--- a/pkg/common/model/slo_prometheus_test.go
+++ b/pkg/common/model/slo_prometheus_test.go
@@ -56,6 +56,9 @@ func getGoodSLO() model.PromSLO {
 }
 
 func TestModelValidationSpec(t *testing.T) {
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
+
 	tests := map[string]struct {
 		slo           func() model.PromSLO
 		expErrMessage string
@@ -430,7 +433,7 @@ func TestModelValidationSpec(t *testing.T) {
 			assert := assert.New(t)
 
 			slo := test.slo()
-			err := slo.Validate()
+			err := slo.Validate(queryValidator)
 
 			if test.expErrMessage != "" {
 				assert.Error(err)

--- a/pkg/prometheus/plugin/slo/v1/testing/testing.go
+++ b/pkg/prometheus/plugin/slo/v1/testing/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/slok/sloth/internal/log"
 	pluginengineslo "github.com/slok/sloth/internal/pluginengine/slo"
+	"github.com/slok/sloth/pkg/common/model"
 	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
 )
 
@@ -50,7 +51,10 @@ func NewTestPlugin(ctx context.Context, config TestPluginConfig) (pluginslov1.Pl
 		return nil, fmt.Errorf("could not load plugin source code: %w", err)
 	}
 
+	var queryValidator model.QueryValidator
+	queryValidator.MetricsQL = true
 	return plugin.PluginV1Factory(config.PluginConfiguration, pluginslov1.AppUtils{
-		Logger: log.Noop,
+		Logger:         log.Noop,
+		QueryValidator: queryValidator,
 	})
 }

--- a/pkg/prometheus/plugin/slo/v1/v1.go
+++ b/pkg/prometheus/plugin/slo/v1/v1.go
@@ -23,7 +23,8 @@ const PluginIDName = "PluginID"
 
 // AppUtils are app utils plugins can use in their logic.
 type AppUtils struct {
-	Logger log.Logger
+	Logger         log.Logger
+	QueryValidator model.QueryValidator
 }
 
 type Request struct {

--- a/test/integration/prometheus/slo_plugins/plugin1/plugin.go
+++ b/test/integration/prometheus/slo_plugins/plugin1/plugin.go
@@ -17,7 +17,7 @@ type Config struct {
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-func NewPlugin(configData json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+func NewPlugin(configData json.RawMessage, appUtils pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
 	cfg := Config{}
 	err := json.Unmarshal(configData, &cfg)
 	if err != nil {
@@ -25,12 +25,14 @@ func NewPlugin(configData json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.
 	}
 
 	return plugin{
-		config: cfg,
+		config:   cfg,
+		appUtils: appUtils,
 	}, nil
 }
 
 type plugin struct {
-	config Config
+	config   Config
+	appUtils pluginslov1.AppUtils
 }
 
 func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {


### PR DESCRIPTION
Introduce a "query dialect" concept to extend the expression validation.

First two dialects:
- PromQL
- VictoriaMetrics MetricsQL

Future dialects:
- LogQL [would need additional work]
- PromQL w/ experimental functions [https://github.com/grafana/mimir/pull/10991]

Based-on: https://github.com/ostrovok-tech/sloth/blob/main/CHANGELOG.md#added-2
Reference: https://github.com/slok/sloth/issues/542
Reference: https://github.com/slok/sloth/issues/280