### PR TITLE
fix: update go version go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slok/sloth
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/OpenSLO/oslo v0.12.0


### PR DESCRIPTION
solves issues with go downloading

https://stackoverflow.com/q/78519711

```
go: downloading go1.24 (linux/amd64)
go: download go1.24 for linux/amd64: toolchain not available
```