### PR TITLE
Aggregate burn rates by extra labels

### DIFF
--- a/internal/app/generate/generate_test.go
+++ b/internal/app/generate/generate_test.go
@@ -320,9 +320,9 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								},
 								{
 									Record: "slo:current_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									Expr: `slo:sli_error:ratio_rate5m{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
+/ on(extra_k1, extra_k2, sloth_id, sloth_service, sloth_slo, test_label) group_left
+slo:error_budget:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
 `,
 									Labels: map[string]string{
 										"test_label":    "label_1",
@@ -335,9 +335,9 @@ slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="
 								},
 								{
 									Record: "slo:period_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									Expr: `slo:sli_error:ratio_rate30d{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
+/ on(extra_k1, extra_k2, sloth_id, sloth_service, sloth_slo, test_label) group_left
+slo:error_budget:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
 `,
 									Labels: map[string]string{
 										"test_label":    "label_1",
@@ -350,7 +350,7 @@ slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="
 								},
 								{
 									Record: "slo:period_error_budget_remaining:ratio",
-									Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
+									Expr:   `1 - slo:period_burn_rate:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}`,
 									Labels: map[string]string{
 										"test_label":    "label_1",
 										"extra_k1":      "extra_v1",
@@ -710,9 +710,9 @@ or
 								},
 								{
 									Record: "slo:current_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									Expr: `slo:sli_error:ratio_rate5m{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
+/ on(extra_k1, extra_k2, sloth_id, sloth_service, sloth_slo, test_label) group_left
+slo:error_budget:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
 `,
 									Labels: map[string]string{
 										"test_label":    "label_1",
@@ -725,9 +725,9 @@ slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="
 								},
 								{
 									Record: "slo:period_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									Expr: `slo:sli_error:ratio_rate30d{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
+/ on(extra_k1, extra_k2, sloth_id, sloth_service, sloth_slo, test_label) group_left
+slo:error_budget:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}
 `,
 									Labels: map[string]string{
 										"test_label":    "label_1",
@@ -740,7 +740,7 @@ slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="
 								},
 								{
 									Record: "slo:period_error_budget_remaining:ratio",
-									Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
+									Expr:   `1 - slo:period_burn_rate:ratio{extra_k1="extra_v1", extra_k2="extra_v2", sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name", test_label="label_1"}`,
 									Labels: map[string]string{
 										"test_label":    "label_1",
 										"extra_k1":      "extra_v1",

--- a/internal/plugin/slo/core/metadata_rules_v1/plugin_test.go
+++ b/internal/plugin/slo/core/metadata_rules_v1/plugin_test.go
@@ -101,9 +101,9 @@ func TestPlugin(t *testing.T) {
 				},
 				{
 					Record: "slo:current_burn_rate:ratio",
-					Expr: `slo:sli_error:ratio_rate5m{sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+					Expr: `slo:sli_error:ratio_rate5m{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+/ on(kind, sloth_id, sloth_service, sloth_slo) group_left
+slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
 `,
 					Labels: map[string]string{
 						"kind":          "test",
@@ -114,9 +114,9 @@ slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="tes
 				},
 				{
 					Record: "slo:period_burn_rate:ratio",
-					Expr: `slo:sli_error:ratio_rate30d{sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
-/ on(sloth_id, sloth_slo, sloth_service) group_left
-slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+					Expr: `slo:sli_error:ratio_rate30d{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
+/ on(kind, sloth_id, sloth_service, sloth_slo) group_left
+slo:error_budget:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}
 `,
 					Labels: map[string]string{
 						"kind":          "test",
@@ -127,7 +127,7 @@ slo:error_budget:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="tes
 				},
 				{
 					Record: "slo:period_error_budget_remaining:ratio",
-					Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}`,
+					Expr:   `1 - slo:period_burn_rate:ratio{kind="test", sloth_id="test", sloth_service="test-svc", sloth_slo="test-name"}`,
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",


### PR DESCRIPTION
We have a few services that we deploy to multiple namespaces. In order differentiate, we add `namespace=service-env` labels to everything. However, the moment we added the SLO to the second namespace, we got the following error:

```
cannot evaluate:
slo:sli_error:ratio_rate30d{sloth_id="service-slo",sloth_service="service",sloth_slo="slo"} / on(sloth_id,sloth_slo,sloth_service) group_left() slo:error_budget:ratio{sloth_id="service-slo",sloth_service="service",sloth_slo="slo"}": duplicate time series on the right side of `/
on(sloth_id,sloth_slo,sloth_service) group_left()`: {sloth_id="service-slo",
sloth_service="service", sloth_slo="slo",
namespace="service-qa"} and
{sloth_id="service-slo",
sloth_service="service", sloth_slo="slo",
namespace="service-dev"}
```

To fix this we can divide the burn rates per the extra labels added, in addition to just filtering on them

Signed-off-by: James M Leddy <james.leddy@mongodb.com>