### PR TITLE
[FEAT] add helm chart nodeselector property

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
       tolerations:
 {{ toYaml . | trim | indent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | trim | indent 8 }}
+      {{- end }}
       containers:
         - name: sloth
           image: {{ coalesce .Values.global.imageRegistry .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom.yaml
@@ -37,6 +37,9 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 100
+      nodeSelector:
+        k1: v1
+        k2: v2
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_extras.yaml
@@ -37,6 +37,9 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 100
+      nodeSelector:
+        k1: v1
+        k2: v2
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_slo_config.yaml
@@ -38,6 +38,9 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         runAsUser: 100
+      nodeSelector:
+        k1: v1
+        k2: v2
       containers:
         - name: sloth
           image: slok/sloth-test:v1.42.42

--- a/deploy/kubernetes/helm/sloth/tests/values_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/values_test.go
@@ -34,6 +34,11 @@ func customValues() msi {
 			},
 		},
 
+		"nodeSelector": msi{
+			"k1": "v1",
+			"k2": "v2",
+		},
+
 		"commonPlugins": msi{
 			"enabled": true,
 			"gitRepo": msi{

--- a/deploy/kubernetes/helm/sloth/values.yaml
+++ b/deploy/kubernetes/helm/sloth/values.yaml
@@ -71,6 +71,10 @@ customSloConfig:
 #     value: spot
 #     effect: NoSchedule
 
+# add deployment pod nodeSelector
+# nodeSelector:
+#   kubernetes.io/arch: "arm64"
+
 securityContext:
   pod: null
   #   fsGroup: 100


### PR DESCRIPTION
To be able to select a node in kubernetes using nodeSelector property:

- **nodeSelector** is used in a Pod specification (usually within a Deployment, StatefulSet, etc.) to tell the scheduler which nodes are eligible to run the Pod, based on node labels.