### PR TITLE
Support reading generate input from os.Stdin

### DIFF
--- a/test/integration/k8scontroller/helpers.go
+++ b/test/integration/k8scontroller/helpers.go
@@ -73,7 +73,7 @@ func RunSlothController(ctx context.Context, config Config, ns string, cmdArgs s
 		fmt.Sprintf("SLOTH_KUBE_LOCAL=%t", true),
 	}
 
-	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("kubernetes-controller %s", cmdArgs), true)
+	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("kubernetes-controller %s", cmdArgs), nil, true)
 }
 
 type KubeClients struct {

--- a/test/integration/prometheus/helpers.go
+++ b/test/integration/prometheus/helpers.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -46,12 +47,12 @@ func NewConfig(t *testing.T) Config {
 	return c
 }
 
-func RunSlothGenerate(ctx context.Context, config Config, cmdArgs string) (stdout, stderr []byte, err error) {
+func RunSlothGenerate(ctx context.Context, config Config, cmdArgs string, input io.Reader) (stdout, stderr []byte, err error) {
 	env := []string{
 		fmt.Sprintf("SLOTH_PLUGINS_PATH=%s", "./plugins"),
 	}
 
-	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("generate %s", cmdArgs), true)
+	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("generate %s", cmdArgs), input, true)
 }
 
 func RunSlothValidate(ctx context.Context, config Config, cmdArgs string) (stdout, stderr []byte, err error) {
@@ -59,5 +60,5 @@ func RunSlothValidate(ctx context.Context, config Config, cmdArgs string) (stdou
 		fmt.Sprintf("SLOTH_PLUGINS_PATH=%s", "./plugins"),
 	}
 
-	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("validate %s", cmdArgs), true)
+	return testutils.RunSloth(ctx, env, config.Binary, fmt.Sprintf("validate %s", cmdArgs), nil, true)
 }


### PR DESCRIPTION
* Passing `--input=-` will read input from `os.Stdin`, similar to how `--out=-` writes to `os.Stdout`
* This allows using `sloth generate` in a shell pipeline. For example:
```
example_preprocess_command | sloth generate --input=- --out=output.yaml
```