### PR TITLE
let to configure granular resources, as is a common practice to remove cpu limits: https://home.robusta.dev/blog/stop-using-cpu-limits

### DIFF
--- a/deploy/kubernetes/helm/sloth/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/sloth/templates/deployment.yaml
@@ -93,7 +93,20 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+            limits:
+            {{- with .Values.resources.limits.cpu }}
+              cpu: {{ . }}
+            {{- end }}
+            {{- with .Values.resources.limits.memory }}
+              memory: {{ . }}
+            {{- end }}
+            requests:
+            {{- with .Values.resources.requests.cpu }}
+              cpu: {{ . }}
+            {{- end }}
+            {{- with .Values.resources.requests.memory }}
+              memory: {{ . }}
+            {{- end }}
         {{- if .Values.commonPlugins.enabled }}
         - name: git-sync-plugins
           image: {{ .Values.commonPlugins.image.repository }}:{{ .Values.commonPlugins.image.tag }}
@@ -111,7 +124,20 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
-          {{- toYaml .Values.commonPlugins.gitRepo.resources | nindent 12 }}
+            limits:
+            {{- with .Values.commonPlugins.gitRepo.resources.limits.cpu }}
+              cpu: {{ . }}
+            {{- end }}
+            {{- with .Values.commonPlugins.gitRepo.resources.limits.memory }}
+              memory: {{ . }}
+            {{- end }}
+            requests:
+            {{- with .Values.commonPlugins.gitRepo.resources.requests.cpu }}
+              cpu: {{ . }}
+            {{- end }}
+            {{- with .Values.commonPlugins.gitRepo.resources.requests.memory }}
+              memory: {{ . }}
+            {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
+++ b/deploy/kubernetes/helm/sloth/tests/helm_chart_test.go
@@ -109,6 +109,18 @@ func TestChartDeployment(t *testing.T) {
 			expTplFile: "testdata/output/deployment_custom_no_extras.yaml",
 		},
 
+		
+		"A chart without cpu limits that should render correclty and don't show cpu limit.": {
+			name:      "test",
+			namespace: "custom",
+			values: func() map[string]interface{} {
+				v := customValues()
+				v["resources"].(msi)["limits"].(msi)["cpu"] = nil
+				return v
+			},
+			expTplFile: "testdata/output/deployment_custom_no_cpu_limit.yaml",
+		},
+
 		"A chart with custom slo config should render correctly.": {
 			name:      "test",
 			namespace: "custom",

--- a/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_cpu_limit.yaml
+++ b/deploy/kubernetes/helm/sloth/tests/testdata/output/deployment_custom_no_cpu_limit.yaml
@@ -1,0 +1,63 @@
+---
+# Source: sloth/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sloth-test
+  namespace: custom
+  labels:
+    helm.sh/chart: sloth-<version>
+    app.kubernetes.io/managed-by: Helm
+    app: sloth
+    app.kubernetes.io/name: sloth
+    app.kubernetes.io/instance: test
+    label-from: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sloth
+      app.kubernetes.io/name: sloth
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: sloth-<version>
+        app.kubernetes.io/managed-by: Helm
+        app: sloth
+        app.kubernetes.io/name: sloth
+        app.kubernetes.io/instance: test
+        label-from: test
+      annotations:
+        kubectl.kubernetes.io/default-container: sloth
+    spec:
+      serviceAccountName: sloth-test
+      securityContext:
+        fsGroup: 100
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 100
+      nodeSelector:
+        k1: v1
+        k2: v2
+      containers:
+        - name: sloth
+          image: slok/sloth-test:v1.42.42
+          args:
+            - kubernetes-controller
+            - --resync-interval=17m
+            - --workers=99
+            - --namespace=somens
+            - --label-selector=x=y,z!=y
+            - --extra-labels=k1=v1
+            - --extra-labels=k2=v2
+            - --disable-optimized-rules
+            - --logger=default
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources:
+            limits:
+              memory: 150Mi
+            requests:
+              cpu: 5m
+              memory: 75Mi


### PR DESCRIPTION
let to configure granular resources, as is a common practice to remove cpu limits: https://home.robusta.dev/blog/stop-using-cpu-limits