### PR TITLE
chore: Bump Helm chart version to v0.12.2

### DIFF
--- a/deploy/kubernetes/helm/sloth/Chart.yaml
+++ b/deploy/kubernetes/helm/sloth/Chart.yaml
@@ -4,4 +4,4 @@ description: Base chart for Sloth.
 type: application
 home: https://github.com/slok/sloth
 kubeVersion: ">= 1.19.0-0"
-version: 0.12.1
+version: 0.12.2

--- a/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
+++ b/deploy/kubernetes/raw/sloth-with-common-plugins.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -59,7 +59,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.12.1
+        helm.sh/chart: sloth-0.12.2
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
@@ -133,7 +133,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth

--- a/deploy/kubernetes/raw/sloth.yaml
+++ b/deploy/kubernetes/raw/sloth.yaml
@@ -6,7 +6,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -18,7 +18,7 @@ kind: ClusterRole
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   name: sloth
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -59,7 +59,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: sloth-0.12.1
+        helm.sh/chart: sloth-0.12.2
         app.kubernetes.io/managed-by: Helm
         app: sloth
         app.kubernetes.io/name: sloth
@@ -108,7 +108,7 @@ metadata:
   name: sloth
   namespace: monitoring
   labels:
-    helm.sh/chart: sloth-0.12.1
+    helm.sh/chart: sloth-0.12.2
     app.kubernetes.io/managed-by: Helm
     app: sloth
     app.kubernetes.io/name: sloth


### PR DESCRIPTION
This PR bumps the version of the Helm chart to v0.12.2.

This is meant to include the latest change to the chart:

- https://github.com/slok/sloth/pull/613