### PR TITLE
Add rule intervals SLO plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 # Specific contrib SLO owners.
 /internal/plugin/slo/contrib/info_labels_v1/                @cxdy @slok @wbollock
 /internal/plugin/slo/contrib/validate_victoria_metrics_v1/  @slok
+/internal/plugin/slo/contrib/rule_intervals_v1/             @cxdy @slok @wbollock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Contrib plugin: `/internal/plugin/slo/contrib/info_labels_v1/`.
 - Allow `github.com/VictoriaMetrics/metricsql` module in SLO plugins.
 - Contrib plugin: `sloth.dev/contrib/validate_victoria_metrics/v1`.
+- Contrib plugin: `sloth.dev/contrib/rule_intervals/v1`.
 
 ## [v0.13.0] - 2025-09-10
 

--- a/examples/_gen/contrib-slo-plugins.yml
+++ b/examples/_gen/contrib-slo-plugins.yml
@@ -250,3 +250,249 @@ groups:
       summary: High error rate on 'myservice' requests responses
       title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
         burn rate is too fast.
+- name: sloth-slo-sli-recordings-myservice-requests-availability-contrib-plugin-rule-intervals-v1
+  interval: 5m
+  rules:
+  - record: slo:sli_error:ratio_rate5m
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 5m
+      tier: "2"
+  - record: slo:sli_error:ratio_rate30m
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 30m
+      tier: "2"
+  - record: slo:sli_error:ratio_rate1h
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 1h
+      tier: "2"
+  - record: slo:sli_error:ratio_rate2h
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 2h
+      tier: "2"
+  - record: slo:sli_error:ratio_rate6h
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 6h
+      tier: "2"
+  - record: slo:sli_error:ratio_rate1d
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 1d
+      tier: "2"
+  - record: slo:sli_error:ratio_rate3d
+    expr: |
+      (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
+      /
+      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 3d
+      tier: "2"
+  - record: slo:sli_error:ratio_rate30d
+    expr: |
+      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}[30d])
+      / ignoring (sloth_window)
+      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}[30d])
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_window: 30d
+      tier: "2"
+- name: sloth-slo-meta-recordings-myservice-requests-availability-contrib-plugin-rule-intervals-v1
+  interval: 5m
+  rules:
+  - record: slo:objective:ratio
+    expr: vector(0.9990000000000001)
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: slo:error_budget:ratio
+    expr: vector(1-0.9990000000000001)
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: slo:time_period:days
+    expr: vector(30)
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: slo:current_burn_rate:ratio
+    expr: |
+      slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}
+      / on(sloth_id, sloth_slo, sloth_service) group_left
+      slo:error_budget:ratio{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: slo:period_burn_rate:ratio
+    expr: |
+      slo:sli_error:ratio_rate30d{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}
+      / on(sloth_id, sloth_slo, sloth_service) group_left
+      slo:error_budget:ratio{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: slo:period_error_budget_remaining:ratio
+    expr: 1 - slo:period_burn_rate:ratio{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1",
+      sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"}
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      tier: "2"
+  - record: sloth_slo_info
+    expr: vector(1)
+    labels:
+      cmd: examplesgen.sh
+      owner: myteam
+      repo: myorg/myservice
+      sloth_id: myservice-requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_mode: cli-gen-prom
+      sloth_objective: "99.9"
+      sloth_service: myservice
+      sloth_slo: requests-availability-contrib-plugin-rule-intervals-v1
+      sloth_spec: prometheus/v1
+      sloth_version: dev
+      tier: "2"
+- name: sloth-slo-alerts-myservice-requests-availability-contrib-plugin-rule-intervals-v1
+  interval: 5m
+  rules:
+  - alert: MyServiceHighErrorRate
+    expr: |
+      (
+          max(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate1h{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (14.4 * 0.0009999999999999432)) without (sloth_window)
+      )
+      or
+      (
+          max(slo:sli_error:ratio_rate30m{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (6 * 0.0009999999999999432)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate6h{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (6 * 0.0009999999999999432)) without (sloth_window)
+      )
+    labels:
+      category: availability
+      routing_key: myteam
+      severity: pageteam
+      sloth_severity: page
+    annotations:
+      summary: High error rate on 'myservice' requests responses
+      title: (page) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
+        burn rate is too fast.
+  - alert: MyServiceHighErrorRate
+    expr: |
+      (
+          max(slo:sli_error:ratio_rate2h{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (3 * 0.0009999999999999432)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate1d{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (3 * 0.0009999999999999432)) without (sloth_window)
+      )
+      or
+      (
+          max(slo:sli_error:ratio_rate6h{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (1 * 0.0009999999999999432)) without (sloth_window)
+          and
+          max(slo:sli_error:ratio_rate3d{sloth_id="myservice-requests-availability-contrib-plugin-rule-intervals-v1", sloth_service="myservice", sloth_slo="requests-availability-contrib-plugin-rule-intervals-v1"} > (1 * 0.0009999999999999432)) without (sloth_window)
+      )
+    labels:
+      category: availability
+      severity: slack
+      slack_channel: '#alerts-myteam'
+      sloth_severity: ticket
+    annotations:
+      summary: High error rate on 'myservice' requests responses
+      title: (ticket) {{$labels.sloth_service}} {{$labels.sloth_slo}} SLO error budget
+        burn rate is too fast.

--- a/examples/contrib-slo-plugins.yml
+++ b/examples/contrib-slo-plugins.yml
@@ -36,3 +36,32 @@ slos:
         labels:
           severity: "slack"
           slack_channel: "#alerts-myteam"
+
+  - name: "requests-availability-contrib-plugin-rule-intervals-v1"
+    objective: 99.9
+    description: "Common SLO based on availability for HTTP request responses."
+    plugins:
+      chain:
+        - id: "sloth.dev/contrib/rule_intervals/v1"
+          config:
+            interval:
+              default: 5m
+    sli:
+      events:
+        error_query: sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[{{.window}}]))
+        total_query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
+    alerting:
+      name: MyServiceHighErrorRate
+      labels:
+        category: "availability"
+      annotations:
+        # Overwrite default Sloth SLO alert summmary on ticket and page alerts.
+        summary: "High error rate on 'myservice' requests responses"
+      page_alert:
+        labels:
+          severity: pageteam
+          routing_key: myteam
+      ticket_alert:
+        labels:
+          severity: "slack"
+          slack_channel: "#alerts-myteam"

--- a/internal/plugin/slo/contrib/rule_intervals_v1/README.md
+++ b/internal/plugin/slo/contrib/rule_intervals_v1/README.md
@@ -1,0 +1,46 @@
+# sloth.dev/contrib/rule_intervals/v1
+
+This plugin sets Prom rule evaluation intervals to the Prometheus generated rules. The intervals can be different depending on the type of rules, SLI, metadata and alerts. A default interval can be set for all rules.
+
+## Config
+
+| Field             | Type                     | Required | Default | Description                                                       |
+|-------------------|--------------------------|----------|---------|-------------------------------------------------------------------|
+| `interval.default` | Prom time duration string  | Yes      | —       | Fallback interval to use if no other interval is set.             |
+| `interval.sliError`| Prom time duration string  | No       | —       | Evaluation rule interval for generated SLI error rules.           |
+| `interval.metadata`| Prom time duration string  | No       | —       | Evaluation rule interval for generated metadata rules.            |
+| `interval.alert`   | Prom time duration string  | No       | —       | Evaluation rule interval for generated alert rules.               |
+
+## Env var
+
+None
+
+## Order requirement
+
+This plugin must be placed **after** all rule generation.
+
+## Usage examples
+
+### Specific settings in an SLO group
+
+```yaml
+slo_plugins:
+  chain:
+    - id: sloth.dev/contrib/rule_intervals/v1
+      config:
+        interval:
+          default: 1m
+          sliError: 42s
+          metadata: 55s
+          alert: 11s
+```
+
+### Add a custom default interval to all rules and SLOs
+
+By adding a default interval at app level, all generated rules by sloth will have that interval
+
+```bash
+sloth generate \
+  -i ./examples/getting-started.yml \
+  -s '{"id": "sloth.dev/contrib/rule_intervals/v1","config":{"interval": {"default":"2m"}}}'
+```

--- a/internal/plugin/slo/contrib/rule_intervals_v1/plugin.go
+++ b/internal/plugin/slo/contrib/rule_intervals_v1/plugin.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
+)
+
+const (
+	PluginVersion = "prometheus/slo/v1"
+	PluginID      = "sloth.dev/contrib/rule_intervals/v1"
+)
+
+type ConfigInterval struct {
+	Default  prommodel.Duration `json:"default,omitempty"`
+	SLIError prommodel.Duration `json:"sliError,omitempty"`
+	Metadata prommodel.Duration `json:"metadata,omitempty"`
+	Alert    prommodel.Duration `json:"alert,omitempty"`
+}
+type Config struct {
+	Interval ConfigInterval `json:"interval,omitempty"`
+}
+
+func NewPlugin(configData json.RawMessage, _ pluginslov1.AppUtils) (pluginslov1.Plugin, error) {
+	config := Config{}
+	err := json.Unmarshal(configData, &config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	if config.Interval.Default == 0 {
+		return nil, fmt.Errorf("at least default interval is required")
+	}
+
+	return plugin{config: config}, nil
+}
+
+type plugin struct {
+	config Config
+}
+
+func (p plugin) ProcessSLO(ctx context.Context, request *pluginslov1.Request, result *pluginslov1.Result) error {
+	result.SLORules.SLIErrorRecRules.Interval = time.Duration(p.config.Interval.Default)
+	if p.config.Interval.SLIError != 0 {
+		result.SLORules.SLIErrorRecRules.Interval = time.Duration(p.config.Interval.SLIError)
+	}
+
+	result.SLORules.MetadataRecRules.Interval = time.Duration(p.config.Interval.Default)
+	if p.config.Interval.Metadata != 0 {
+		result.SLORules.MetadataRecRules.Interval = time.Duration(p.config.Interval.Metadata)
+	}
+
+	result.SLORules.AlertRules.Interval = time.Duration(p.config.Interval.Default)
+	if p.config.Interval.Alert != 0 {
+		result.SLORules.AlertRules.Interval = time.Duration(p.config.Interval.Alert)
+	}
+
+	return nil
+}

--- a/internal/plugin/slo/contrib/rule_intervals_v1/plugin_test.go
+++ b/internal/plugin/slo/contrib/rule_intervals_v1/plugin_test.go
@@ -1,0 +1,122 @@
+package plugin_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	plugin "github.com/slok/sloth/internal/plugin/slo/contrib/rule_intervals_v1"
+	"github.com/slok/sloth/pkg/common/model"
+	pluginslov1 "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1"
+	pluginslov1testing "github.com/slok/sloth/pkg/prometheus/plugin/slo/v1/testing"
+)
+
+func MustJSONRawMessage(t *testing.T, v any) json.RawMessage {
+	j, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal %T: %v", v, err)
+	}
+	return j
+}
+
+func TestPlugin(t *testing.T) {
+	tests := map[string]struct {
+		config     json.RawMessage
+		req        pluginslov1.Request
+		expRes     pluginslov1.Result
+		expLoadErr bool
+		expErr     bool
+	}{
+		"A config without default time should fail.": {
+			config: MustJSONRawMessage(t, plugin.Config{Interval: plugin.ConfigInterval{
+				SLIError: prommodel.Duration(43 * time.Second),
+				Metadata: prommodel.Duration(44 * time.Second),
+				Alert:    prommodel.Duration(45 * time.Second),
+			}}),
+			expLoadErr: true,
+		},
+
+		"Having intervals for each of the rule types, it should load them.": {
+			config: MustJSONRawMessage(t, plugin.Config{Interval: plugin.ConfigInterval{
+				Default:  prommodel.Duration(42 * time.Second),
+				SLIError: prommodel.Duration(43 * time.Second),
+				Metadata: prommodel.Duration(44 * time.Second),
+				Alert:    prommodel.Duration(45 * time.Second),
+			}}),
+			req: pluginslov1.Request{},
+			expRes: pluginslov1.Result{
+				SLORules: model.PromSLORules{
+					SLIErrorRecRules: model.PromRuleGroup{Interval: 43 * time.Second},
+					MetadataRecRules: model.PromRuleGroup{Interval: 44 * time.Second},
+					AlertRules:       model.PromRuleGroup{Interval: 45 * time.Second},
+				},
+			},
+		},
+
+		"Having empty intervals for specific rule types, should fallback.": {
+			config: MustJSONRawMessage(t, plugin.Config{Interval: plugin.ConfigInterval{
+				Default: prommodel.Duration(42 * time.Second),
+			}}),
+			req: pluginslov1.Request{},
+			expRes: pluginslov1.Result{
+				SLORules: model.PromSLORules{
+					SLIErrorRecRules: model.PromRuleGroup{Interval: 42 * time.Second},
+					MetadataRecRules: model.PromRuleGroup{Interval: 42 * time.Second},
+					AlertRules:       model.PromRuleGroup{Interval: 42 * time.Second},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			plugin, err := pluginslov1testing.NewTestPlugin(t.Context(), pluginslov1testing.TestPluginConfig{PluginConfiguration: test.config})
+			if test.expLoadErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+
+			res := pluginslov1.Result{}
+			err = plugin.ProcessSLO(t.Context(), &test.req, &res)
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				assert.Equal(test.expRes, res)
+			}
+		})
+	}
+}
+
+func BenchmarkPluginYaegi(b *testing.B) {
+	plugin, err := pluginslov1testing.NewTestPlugin(b.Context(), pluginslov1testing.TestPluginConfig{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		err = plugin.ProcessSLO(b.Context(), &pluginslov1.Request{}, &pluginslov1.Result{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPluginGo(b *testing.B) {
+	plugin, err := plugin.NewPlugin(nil, pluginslov1.AppUtils{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		err = plugin.ProcessSLO(b.Context(), &pluginslov1.Request{}, &pluginslov1.Result{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Adds a plugin for setting custom rule intervals for the recording rules generated by Sloth, this feature was used by @cxdy and @wbollock on their fork. So we are adding it as a contrib plugin.