### PR TITLE
chore: tiny markdown heading fix

### DIFF
--- a/internal/plugin/slo/contrib/validate_victoria_metrics_v1/README.md
+++ b/internal/plugin/slo/contrib/validate_victoria_metrics_v1/README.md
@@ -32,7 +32,7 @@ slo_plugins:
     - id: sloth.dev/core/alert_rules/v1 # Default set again.
 ```
 
-### Explicit usage as app plugin
+### Explicit usage as app plugin
 
 Disable all default logic and set a new logic for all the Sloth app by setting the custom victoria metrics validator plugin and setting again default Sloth SLO generator plugins.
 


### PR DESCRIPTION
super tiny markdown heading fix so it renders the heading right