### PR TITLE
Improve how default generated rule group names are set

### DIFF
--- a/internal/app/generate/generate_test.go
+++ b/internal/app/generate/generate_test.go
@@ -175,210 +175,215 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 							},
 						},
 						SLORules: model.PromSLORules{
-							SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-								{
-									Record: "slo:sli_error:ratio_rate5m",
-									Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "5m",
+							SLIErrorRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-sli-recordings-test-id",
+								Rules: []rulefmt.Rule{
+									{
+										Record: "slo:sli_error:ratio_rate5m",
+										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "5m",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate30m",
-									Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "30m",
+									{
+										Record: "slo:sli_error:ratio_rate30m",
+										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "30m",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate1h",
-									Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "1h",
+									{
+										Record: "slo:sli_error:ratio_rate1h",
+										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "1h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate2h",
-									Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "2h",
+									{
+										Record: "slo:sli_error:ratio_rate2h",
+										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "2h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate6h",
-									Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "6h",
+									{
+										Record: "slo:sli_error:ratio_rate6h",
+										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "6h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate1d",
-									Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "1d",
+									{
+										Record: "slo:sli_error:ratio_rate1d",
+										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "1d",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate3d",
-									Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "3d",
+									{
+										Record: "slo:sli_error:ratio_rate3d",
+										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "3d",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate30d",
-									Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "30d",
+									{
+										Record: "slo:sli_error:ratio_rate30d",
+										Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "30d",
+										},
 									},
-								},
-							}},
-							MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-								// Metadata labels.
-								{
-									Record: "slo:objective:ratio",
-									Expr:   "vector(0.9990000000000001)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+								}},
+							MetadataRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-meta-recordings-test-id",
+								Rules: []rulefmt.Rule{
+									// Metadata labels.
+									{
+										Record: "slo:objective:ratio",
+										Expr:   "vector(0.9990000000000001)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:error_budget:ratio",
-									Expr:   "vector(1-0.9990000000000001)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:error_budget:ratio",
+										Expr:   "vector(1-0.9990000000000001)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:time_period:days",
-									Expr:   "vector(30)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:time_period:days",
+										Expr:   "vector(30)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:current_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									{
+										Record: "slo:current_burn_rate:ratio",
+										Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 / on(sloth_id, sloth_slo, sloth_service) group_left
 slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 `,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:period_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									{
+										Record: "slo:period_burn_rate:ratio",
+										Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 / on(sloth_id, sloth_slo, sloth_service) group_left
 slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 `,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:period_error_budget_remaining:ratio",
-									Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:period_error_budget_remaining:ratio",
+										Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "sloth_slo_info",
-									Expr:   `vector(1)`,
-									Labels: map[string]string{
-										"test_label":      "label_1",
-										"extra_k1":        "extra_v1",
-										"extra_k2":        "extra_v2",
-										"sloth_service":   "test-svc",
-										"sloth_slo":       "test-name",
-										"sloth_id":        "test-id",
-										"sloth_mode":      "test",
-										"sloth_version":   "test-ver",
-										"sloth_spec":      "test-spec",
-										"sloth_objective": "99.9",
+									{
+										Record: "sloth_slo_info",
+										Expr:   `vector(1)`,
+										Labels: map[string]string{
+											"test_label":      "label_1",
+											"extra_k1":        "extra_v1",
+											"extra_k2":        "extra_v2",
+											"sloth_service":   "test-svc",
+											"sloth_slo":       "test-name",
+											"sloth_id":        "test-id",
+											"sloth_mode":      "test",
+											"sloth_version":   "test-ver",
+											"sloth_spec":      "test-spec",
+											"sloth_objective": "99.9",
+										},
 									},
-								},
-							}},
+								}},
 							AlertRules: model.PromRuleGroup{
+								Name:     "sloth-slo-alerts-test-id",
 								Interval: 99 * time.Minute, // From the SLO plugins.
 								Rules: []rulefmt.Rule{
 									{
@@ -583,210 +588,215 @@ or
 							},
 						},
 						SLORules: model.PromSLORules{
-							SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-								{
-									Record: "slo:sli_error:ratio_rate5m",
-									Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "5m",
+							SLIErrorRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-sli-recordings-test-id",
+								Rules: []rulefmt.Rule{
+									{
+										Record: "slo:sli_error:ratio_rate5m",
+										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "5m",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate30m",
-									Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "30m",
+									{
+										Record: "slo:sli_error:ratio_rate30m",
+										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "30m",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate1h",
-									Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "1h",
+									{
+										Record: "slo:sli_error:ratio_rate1h",
+										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "1h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate2h",
-									Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "2h",
+									{
+										Record: "slo:sli_error:ratio_rate2h",
+										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "2h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate6h",
-									Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "6h",
+									{
+										Record: "slo:sli_error:ratio_rate6h",
+										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "6h",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate1d",
-									Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "1d",
+									{
+										Record: "slo:sli_error:ratio_rate1d",
+										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "1d",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate3d",
-									Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "3d",
+									{
+										Record: "slo:sli_error:ratio_rate3d",
+										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "3d",
+										},
 									},
-								},
-								{
-									Record: "slo:sli_error:ratio_rate30d",
-									Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
-										"sloth_window":  "30d",
+									{
+										Record: "slo:sli_error:ratio_rate30d",
+										Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+											"sloth_window":  "30d",
+										},
 									},
-								},
-							}},
-							MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-								// Metadata labels.
-								{
-									Record: "slo:objective:ratio",
-									Expr:   "vector(0.9990000000000001)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+								}},
+							MetadataRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-meta-recordings-test-id",
+								Rules: []rulefmt.Rule{
+									// Metadata labels.
+									{
+										Record: "slo:objective:ratio",
+										Expr:   "vector(0.9990000000000001)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:error_budget:ratio",
-									Expr:   "vector(1-0.9990000000000001)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:error_budget:ratio",
+										Expr:   "vector(1-0.9990000000000001)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:time_period:days",
-									Expr:   "vector(30)",
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:time_period:days",
+										Expr:   "vector(30)",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:current_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									{
+										Record: "slo:current_burn_rate:ratio",
+										Expr: `slo:sli_error:ratio_rate5m{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 / on(sloth_id, sloth_slo, sloth_service) group_left
 slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 `,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:period_burn_rate:ratio",
-									Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
+									{
+										Record: "slo:period_burn_rate:ratio",
+										Expr: `slo:sli_error:ratio_rate30d{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 / on(sloth_id, sloth_slo, sloth_service) group_left
 slo:error_budget:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}
 `,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "slo:period_error_budget_remaining:ratio",
-									Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
-									Labels: map[string]string{
-										"test_label":    "label_1",
-										"extra_k1":      "extra_v1",
-										"extra_k2":      "extra_v2",
-										"sloth_service": "test-svc",
-										"sloth_slo":     "test-name",
-										"sloth_id":      "test-id",
+									{
+										Record: "slo:period_error_budget_remaining:ratio",
+										Expr:   `1 - slo:period_burn_rate:ratio{sloth_id="test-id", sloth_service="test-svc", sloth_slo="test-name"}`,
+										Labels: map[string]string{
+											"test_label":    "label_1",
+											"extra_k1":      "extra_v1",
+											"extra_k2":      "extra_v2",
+											"sloth_service": "test-svc",
+											"sloth_slo":     "test-name",
+											"sloth_id":      "test-id",
+										},
 									},
-								},
-								{
-									Record: "sloth_slo_info",
-									Expr:   `vector(1)`,
-									Labels: map[string]string{
-										"test_label":      "label_1",
-										"extra_k1":        "extra_v1",
-										"extra_k2":        "extra_v2",
-										"sloth_service":   "test-svc",
-										"sloth_slo":       "test-name",
-										"sloth_id":        "test-id",
-										"sloth_mode":      "test",
-										"sloth_version":   "test-ver",
-										"sloth_spec":      "test-spec",
-										"sloth_objective": "99.9",
+									{
+										Record: "sloth_slo_info",
+										Expr:   `vector(1)`,
+										Labels: map[string]string{
+											"test_label":      "label_1",
+											"extra_k1":        "extra_v1",
+											"extra_k2":        "extra_v2",
+											"sloth_service":   "test-svc",
+											"sloth_slo":       "test-name",
+											"sloth_id":        "test-id",
+											"sloth_mode":      "test",
+											"sloth_version":   "test-ver",
+											"sloth_spec":      "test-spec",
+											"sloth_objective": "99.9",
+										},
 									},
-								},
-							}},
+								}},
 							AlertRules: model.PromRuleGroup{
+								Name: "sloth-slo-alerts-test-id",
 								Rules: []rulefmt.Rule{
 									{
 										Alert: "p_alert_test_name",
@@ -903,9 +913,18 @@ or
 							},
 						},
 						SLORules: model.PromSLORules{
-							AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-								{Expr: "test1"},
-							}},
+							SLIErrorRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-sli-recordings-test-id",
+							},
+							MetadataRecRules: model.PromRuleGroup{
+								Name: "sloth-slo-meta-recordings-test-id",
+							},
+							AlertRules: model.PromRuleGroup{
+								Name: "sloth-slo-alerts-test-id",
+								Rules: []rulefmt.Rule{
+									{Expr: "test1"},
+								},
+							},
 						},
 					},
 				},

--- a/internal/kubernetes/modelmap/slo.go
+++ b/internal/kubernetes/modelmap/slo.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/slok/sloth/internal/storage"
-	"github.com/slok/sloth/pkg/common/conventions"
 	commonerrors "github.com/slok/sloth/pkg/common/errors"
 	promutils "github.com/slok/sloth/pkg/common/utils/prometheus"
 )
@@ -45,54 +44,38 @@ func MapModelToPrometheusOperator(ctx context.Context, kmeta storage.K8sMeta, sl
 
 	for _, slo := range slos {
 		if len(slo.Rules.SLIErrorRecRules.Rules) > 0 {
-			name := slo.Rules.SLIErrorRecRules.Name
-			if name == "" {
-				name = conventions.PromRuleGroupNameSLOSLIPrefix + slo.SLO.ID
-			}
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Interval: timeDurationToPromOpDuration(slo.Rules.SLIErrorRecRules.Interval),
-				Name:     name,
+				Name:     slo.Rules.SLIErrorRecRules.Name,
 				Rules:    promRulesToKubeRules(slo.Rules.SLIErrorRecRules.Rules),
 			})
 		}
 
 		if len(slo.Rules.MetadataRecRules.Rules) > 0 {
-			name := slo.Rules.MetadataRecRules.Name
-			if name == "" {
-				name = conventions.PromRuleGroupNameSLOMetadataPrefix + slo.SLO.ID
-			}
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Interval: timeDurationToPromOpDuration(slo.Rules.MetadataRecRules.Interval),
-				Name:     name,
+				Name:     slo.Rules.MetadataRecRules.Name,
 				Rules:    promRulesToKubeRules(slo.Rules.MetadataRecRules.Rules),
 			})
 		}
 
 		if len(slo.Rules.AlertRules.Rules) > 0 {
-			name := slo.Rules.AlertRules.Name
-			if name == "" {
-				name = conventions.PromRuleGroupNameSLOAlertsPrefix + slo.SLO.ID
-			}
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Interval: timeDurationToPromOpDuration(slo.Rules.AlertRules.Interval),
-				Name:     name,
+				Name:     slo.Rules.AlertRules.Name,
 				Rules:    promRulesToKubeRules(slo.Rules.AlertRules.Rules),
 			})
 		}
 
 		// Extra rules.
-		for i, extraRuleGroup := range slo.Rules.ExtraRules {
+		for _, extraRuleGroup := range slo.Rules.ExtraRules {
 			if len(extraRuleGroup.Rules) == 0 {
 				continue
 			}
 
-			name := extraRuleGroup.Name
-			if name == "" {
-				name = fmt.Sprintf("%s%03d-%s", conventions.PromRuleGroupNameSLOExtraRulesPrefix, i, slo.SLO.ID)
-			}
 			rule.Spec.Groups = append(rule.Spec.Groups, monitoringv1.RuleGroup{
 				Interval: timeDurationToPromOpDuration(extraRuleGroup.Interval),
-				Name:     name,
+				Name:     extraRuleGroup.Name,
 				Rules:    promRulesToKubeRules(extraRuleGroup.Rules),
 			})
 		}

--- a/internal/storage/io/prometheus_operator_test.go
+++ b/internal/storage/io/prometheus_operator_test.go
@@ -47,13 +47,15 @@ func TestIOWriterPrometheusOperatorYAMLRepo(t *testing.T) {
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record",
-								Expr:   "test-expr",
-								Labels: map[string]string{"test-label": "one"},
-							},
-						}},
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-test1",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record",
+									Expr:   "test-expr",
+									Labels: map[string]string{"test-label": "one"},
+								},
+							}},
 					},
 				},
 			},
@@ -96,6 +98,7 @@ spec:
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
 						MetadataRecRules: model.PromRuleGroup{
+							Name:     "sloth-slo-meta-recordings-test1",
 							Interval: 42 * time.Minute,
 							Rules: []rulefmt.Rule{
 								{
@@ -146,14 +149,16 @@ spec:
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Alert:       "testAlert",
-								Expr:        "test-expr",
-								Labels:      map[string]string{"test-label": "one"},
-								Annotations: map[string]string{"test-annot": "one"},
-							},
-						}},
+						AlertRules: model.PromRuleGroup{
+							Name: "sloth-slo-alerts-test1",
+							Rules: []rulefmt.Rule{
+								{
+									Alert:       "testAlert",
+									Expr:        "test-expr",
+									Labels:      map[string]string{"test-label": "one"},
+									Annotations: map[string]string{"test-annot": "one"},
+								},
+							}},
 					},
 				},
 			},
@@ -197,20 +202,22 @@ spec:
 				{
 					SLO: model.PromSLO{ID: "testa"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-a1",
-								Expr:   "test-expr-a1",
-								Labels: map[string]string{"test-label": "a-1"},
-							},
-							{
-								Record: "test:record-a2",
-								Expr:   "test-expr-a2",
-								Labels: map[string]string{"test-label": "a-2"},
-							},
-						}},
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testa",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-a1",
+									Expr:   "test-expr-a1",
+									Labels: map[string]string{"test-label": "a-1"},
+								},
+								{
+									Record: "test:record-a2",
+									Expr:   "test-expr-a2",
+									Labels: map[string]string{"test-label": "a-2"},
+								},
+							}},
 						MetadataRecRules: model.PromRuleGroup{
-							Name: "custom-metadata-name-testa", // Custom name.
+							Name: "sloth-slo-meta-recordings-testa",
 							Rules: []rulefmt.Rule{
 								{
 									Record: "test:record-a3",
@@ -224,6 +231,7 @@ spec:
 								},
 							}},
 						AlertRules: model.PromRuleGroup{
+							Name:     "sloth-slo-alerts-testa",
 							Interval: 15 * time.Minute, // Custom interval.
 							Rules: []rulefmt.Rule{
 								{
@@ -244,40 +252,49 @@ spec:
 				{
 					SLO: model.PromSLO{ID: "testb"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b1",
-								Expr:   "test-expr-b1",
-								Labels: map[string]string{"test-label": "b-1"},
-							},
-						}},
-						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b2",
-								Expr:   "test-expr-b2",
-								Labels: map[string]string{"test-label": "b-2"},
-							},
-						}},
-						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Alert:       "testAlertB1",
-								Expr:        "test-expr-b1",
-								Labels:      map[string]string{"test-label": "b-1"},
-								Annotations: map[string]string{"test-annot": "b-1"},
-							},
-						}},
-						ExtraRules: []model.PromRuleGroup{
-							{Interval: 42 * time.Minute, Rules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testb",
+							Rules: []rulefmt.Rule{
 								{
-									Alert:       "testAlertZ1",
-									Expr:        "test-expr-z1",
-									Labels:      map[string]string{"test-label": "z-1"},
-									Annotations: map[string]string{"test-annot": "z-1"},
+									Record: "test:record-b1",
+									Expr:   "test-expr-b1",
+									Labels: map[string]string{"test-label": "b-1"},
 								},
 							}},
+						MetadataRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-meta-recordings-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-b2",
+									Expr:   "test-expr-b2",
+									Labels: map[string]string{"test-label": "b-2"},
+								},
+							}},
+						AlertRules: model.PromRuleGroup{
+							Name: "sloth-slo-alerts-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Alert:       "testAlertB1",
+									Expr:        "test-expr-b1",
+									Labels:      map[string]string{"test-label": "b-1"},
+									Annotations: map[string]string{"test-annot": "b-1"},
+								},
+							}},
+						ExtraRules: []model.PromRuleGroup{
+							{
+								Name:     "sloth-slo-extra-rules-000-testb",
+								Interval: 42 * time.Minute,
+								Rules: []rulefmt.Rule{
+									{
+										Alert:       "testAlertZ1",
+										Expr:        "test-expr-z1",
+										Labels:      map[string]string{"test-label": "z-1"},
+										Annotations: map[string]string{"test-annot": "z-1"},
+									},
+								}},
 							{}, // Should be skipped.
 							{
-								Name: "custom-test-for-extra-rules-zzzzz",
+								Name: "sloth-slo-extra-rules-001-testb",
 								Rules: []rulefmt.Rule{
 									{
 										Alert:       "testAlertZ2",
@@ -325,7 +342,7 @@ spec:
       labels:
         test-label: a-2
       record: test:record-a2
-  - name: custom-metadata-name-testa
+  - name: sloth-slo-meta-recordings-testa
     rules:
     - expr: test-expr-a3
       labels:
@@ -379,7 +396,7 @@ spec:
       expr: test-expr-z1
       labels:
         test-label: z-1
-  - name: custom-test-for-extra-rules-zzzzz
+  - name: sloth-slo-extra-rules-001-testb
     rules:
     - alert: testAlertZ2
       annotations:

--- a/internal/storage/io/std_prometheus_test.go
+++ b/internal/storage/io/std_prometheus_test.go
@@ -37,13 +37,15 @@ func TestGroupedRulesYAMLRepoStore(t *testing.T) {
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record",
-								Expr:   "test-expr",
-								Labels: map[string]string{"test-label": "one"},
-							},
-						}},
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-test1",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record",
+									Expr:   "test-expr",
+									Labels: map[string]string{"test-label": "one"},
+								},
+							}},
 					},
 				},
 			},
@@ -66,13 +68,15 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
-						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record",
-								Expr:   "test-expr",
-								Labels: map[string]string{"test-label": "one"},
-							},
-						}},
+						MetadataRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-meta-recordings-test1",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record",
+									Expr:   "test-expr",
+									Labels: map[string]string{"test-label": "one"},
+								},
+							}},
 					},
 				},
 			},
@@ -96,6 +100,7 @@ groups:
 					SLO: model.PromSLO{ID: "test1"},
 					Rules: model.PromSLORules{
 						AlertRules: model.PromRuleGroup{
+							Name:     "sloth-slo-alerts-test1",
 							Interval: 42 * time.Minute,
 							Rules: []rulefmt.Rule{
 								{
@@ -131,20 +136,22 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "testa"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-a1",
-								Expr:   "test-expr-a1",
-								Labels: map[string]string{"test-label": "a-1"},
-							},
-							{
-								Record: "test:record-a2",
-								Expr:   "test-expr-a2",
-								Labels: map[string]string{"test-label": "a-2"},
-							},
-						}},
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testa",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-a1",
+									Expr:   "test-expr-a1",
+									Labels: map[string]string{"test-label": "a-1"},
+								},
+								{
+									Record: "test:record-a2",
+									Expr:   "test-expr-a2",
+									Labels: map[string]string{"test-label": "a-2"},
+								},
+							}},
 						MetadataRecRules: model.PromRuleGroup{
-							Name: "custom-metadata-name-testa", // Custom name.
+							Name: "sloth-slo-meta-recordings-testa",
 							Rules: []rulefmt.Rule{
 								{
 									Record: "test:record-a3",
@@ -158,6 +165,7 @@ groups:
 								},
 							}},
 						AlertRules: model.PromRuleGroup{
+							Name:     "sloth-slo-alerts-testa",
 							Interval: 15 * time.Minute, // Custom interval.
 							Rules: []rulefmt.Rule{
 								{
@@ -178,40 +186,48 @@ groups:
 				{
 					SLO: model.PromSLO{ID: "testb"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b1",
-								Expr:   "test-expr-b1",
-								Labels: map[string]string{"test-label": "b-1"},
-							},
-						}},
-						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b2",
-								Expr:   "test-expr-b2",
-								Labels: map[string]string{"test-label": "b-2"},
-							},
-						}},
-						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Alert:       "testAlertB1",
-								Expr:        "test-expr-b1",
-								Labels:      map[string]string{"test-label": "b-1"},
-								Annotations: map[string]string{"test-annot": "b-1"},
-							},
-						}},
-						ExtraRules: []model.PromRuleGroup{
-							{Interval: 42 * time.Minute, Rules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testb",
+							Rules: []rulefmt.Rule{
 								{
-									Alert:       "testAlertZ1",
-									Expr:        "test-expr-z1",
-									Labels:      map[string]string{"test-label": "z-1"},
-									Annotations: map[string]string{"test-annot": "z-1"},
+									Record: "test:record-b1",
+									Expr:   "test-expr-b1",
+									Labels: map[string]string{"test-label": "b-1"},
 								},
 							}},
+						MetadataRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-meta-recordings-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-b2",
+									Expr:   "test-expr-b2",
+									Labels: map[string]string{"test-label": "b-2"},
+								},
+							}},
+						AlertRules: model.PromRuleGroup{
+							Name: "sloth-slo-alerts-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Alert:       "testAlertB1",
+									Expr:        "test-expr-b1",
+									Labels:      map[string]string{"test-label": "b-1"},
+									Annotations: map[string]string{"test-annot": "b-1"},
+								},
+							}},
+						ExtraRules: []model.PromRuleGroup{
+							{
+								Name:     "sloth-slo-extra-rules-000-testb",
+								Interval: 42 * time.Minute, Rules: []rulefmt.Rule{
+									{
+										Alert:       "testAlertZ1",
+										Expr:        "test-expr-z1",
+										Labels:      map[string]string{"test-label": "z-1"},
+										Annotations: map[string]string{"test-annot": "z-1"},
+									},
+								}},
 							{}, // Should be skipped.
 							{
-								Name: "custom-test-for-extra-rules-zzzzz",
+								Name: "sloth-slo-extra-rules-001-testb",
 								Rules: []rulefmt.Rule{
 									{
 										Alert:       "testAlertZ2",
@@ -247,7 +263,7 @@ groups:
     expr: test-expr-a2
     labels:
       test-label: a-2
-- name: custom-metadata-name-testa
+- name: sloth-slo-meta-recordings-testa
   rules:
   - record: test:record-a3
     expr: test-expr-a3
@@ -301,7 +317,7 @@ groups:
       test-label: z-1
     annotations:
       test-annot: z-1
-- name: custom-test-for-extra-rules-zzzzz
+- name: sloth-slo-extra-rules-001-testb
   rules:
   - alert: testAlertZ2
     expr: test-expr-z2

--- a/internal/storage/k8s/k8s_test.go
+++ b/internal/storage/k8s/k8s_test.go
@@ -56,20 +56,22 @@ func TestApiserverRepositoryStoreSLOs(t *testing.T) {
 				{
 					SLO: model.PromSLO{ID: "testa"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-a1",
-								Expr:   "test-expr-a1",
-								Labels: map[string]string{"test-label": "a-1"},
-							},
-							{
-								Record: "test:record-a2",
-								Expr:   "test-expr-a2",
-								Labels: map[string]string{"test-label": "a-2"},
-							},
-						}},
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testa",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-a1",
+									Expr:   "test-expr-a1",
+									Labels: map[string]string{"test-label": "a-1"},
+								},
+								{
+									Record: "test:record-a2",
+									Expr:   "test-expr-a2",
+									Labels: map[string]string{"test-label": "a-2"},
+								},
+							}},
 						MetadataRecRules: model.PromRuleGroup{
-							Name: "custom-metadata-name-testa", // Custom name.
+							Name: "sloth-slo-meta-recordings-testa",
 							Rules: []rulefmt.Rule{
 								{
 									Record: "test:record-a3",
@@ -83,6 +85,7 @@ func TestApiserverRepositoryStoreSLOs(t *testing.T) {
 								},
 							}},
 						AlertRules: model.PromRuleGroup{
+							Name:     "sloth-slo-alerts-testa",
 							Interval: 15 * time.Minute, // Custom interval.
 							Rules: []rulefmt.Rule{
 								{
@@ -103,40 +106,49 @@ func TestApiserverRepositoryStoreSLOs(t *testing.T) {
 				{
 					SLO: model.PromSLO{ID: "testb"},
 					Rules: model.PromSLORules{
-						SLIErrorRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b1",
-								Expr:   "test-expr-b1",
-								Labels: map[string]string{"test-label": "b-1"},
-							},
-						}},
-						MetadataRecRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Record: "test:record-b2",
-								Expr:   "test-expr-b2",
-								Labels: map[string]string{"test-label": "b-2"},
-							},
-						}},
-						AlertRules: model.PromRuleGroup{Rules: []rulefmt.Rule{
-							{
-								Alert:       "testAlertB1",
-								Expr:        "test-expr-b1",
-								Labels:      map[string]string{"test-label": "b-1"},
-								Annotations: map[string]string{"test-annot": "b-1"},
-							},
-						}},
-						ExtraRules: []model.PromRuleGroup{
-							{Interval: 42 * time.Minute, Rules: []rulefmt.Rule{
+						SLIErrorRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-sli-recordings-testb",
+							Rules: []rulefmt.Rule{
 								{
-									Alert:       "testAlertZ1",
-									Expr:        "test-expr-z1",
-									Labels:      map[string]string{"test-label": "z-1"},
-									Annotations: map[string]string{"test-annot": "z-1"},
+									Record: "test:record-b1",
+									Expr:   "test-expr-b1",
+									Labels: map[string]string{"test-label": "b-1"},
 								},
 							}},
+						MetadataRecRules: model.PromRuleGroup{
+							Name: "sloth-slo-meta-recordings-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Record: "test:record-b2",
+									Expr:   "test-expr-b2",
+									Labels: map[string]string{"test-label": "b-2"},
+								},
+							}},
+						AlertRules: model.PromRuleGroup{
+							Name: "sloth-slo-alerts-testb",
+							Rules: []rulefmt.Rule{
+								{
+									Alert:       "testAlertB1",
+									Expr:        "test-expr-b1",
+									Labels:      map[string]string{"test-label": "b-1"},
+									Annotations: map[string]string{"test-annot": "b-1"},
+								},
+							}},
+						ExtraRules: []model.PromRuleGroup{
+							{
+								Name:     "sloth-slo-extra-rules-000-testb",
+								Interval: 42 * time.Minute,
+								Rules: []rulefmt.Rule{
+									{
+										Alert:       "testAlertZ1",
+										Expr:        "test-expr-z1",
+										Labels:      map[string]string{"test-label": "z-1"},
+										Annotations: map[string]string{"test-annot": "z-1"},
+									},
+								}},
 							{}, // Should be skipped.
 							{
-								Name: "custom-test-for-extra-rules-zzzzz",
+								Name: "sloth-slo-extra-rules-001-testb",
 								Rules: []rulefmt.Rule{
 									{
 										Alert:       "testAlertZ2",
@@ -198,7 +210,7 @@ func TestApiserverRepositoryStoreSLOs(t *testing.T) {
 								},
 							},
 							{
-								Name: "custom-metadata-name-testa",
+								Name: "sloth-slo-meta-recordings-testa",
 								Rules: []monitoringv1.Rule{
 									{
 										Record: "test:record-a3",
@@ -274,7 +286,7 @@ func TestApiserverRepositoryStoreSLOs(t *testing.T) {
 								},
 							},
 							{
-								Name: "custom-test-for-extra-rules-zzzzz",
+								Name: "sloth-slo-extra-rules-001-testb",
 								Rules: []monitoringv1.Rule{
 									{
 										Alert:       "testAlertZ2",


### PR DESCRIPTION
The autogenerated naming now is on the app (domain logic), that way doesn't depend on the different storages.