### PR TITLE
Add group based SLOs support on UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - UI: Service listing and searching.
 - UI: SLO listing, searching and filtered by service.
 - UI: SLO details with stats, alerts state, SLI chart and budged burn in period chart.
+- UI: Support SLO grouped by labels.
 
 ### Changed
 

--- a/internal/http/backend/model/model.go
+++ b/internal/http/backend/model/model.go
@@ -1,16 +1,25 @@
 package model
 
-import "time"
+import (
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
 
 type Service struct {
 	ID string
 }
 
 type SLO struct {
-	ID             string
+	ID             string // ID is unique for an SLO and grouped SLOs.
+	SlothID        string // SlothID is the ID set by Sloth on Prometheus (if grouped by labels SLO they will share this ID).
 	Name           string
 	ServiceID      string
 	Objective      float64
+	GroupLabels    map[string]string // Some SLOs are grouped by labels under the umbrella of the same SLO spec.
+	IsGrouped      bool
 	PeriodDuration time.Duration
 }
 
@@ -34,4 +43,39 @@ type DataPoint struct {
 	Value   float64
 	Missing bool // Easier than using float64 nil pointers.
 	TS      time.Time
+}
+
+func SLOGroupLabelsIDMarshal(sloID string, labels map[string]string) string {
+	lps := []string{}
+	for k, v := range labels {
+		lps = append(lps, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.SliceStable(lps, func(i, j int) bool { return lps[i] < lps[j] })
+	lpb64 := base64.URLEncoding.EncodeToString([]byte(strings.Join(lps, ",")))
+
+	return fmt.Sprintf("%s:%s", sloID, lpb64)
+}
+
+func SLOGroupLabelsIDUnmarshal(id string) (sloID string, labels map[string]string, err error) {
+	id, b64Labels, ok := strings.Cut(id, ":")
+	if !ok {
+		return id, nil, nil
+	}
+
+	decodedLabels, err := base64.URLEncoding.DecodeString(b64Labels)
+	if err != nil {
+		return "", nil, fmt.Errorf("could not decode base64 labels: %w", err)
+	}
+
+	labels = map[string]string{}
+	for _, lp := range strings.Split(string(decodedLabels), ",") {
+		k, v, ok := strings.Cut(lp, "=")
+		if !ok || k == "" || v == "" {
+			return "", nil, fmt.Errorf("invalid label pair in decoded labels: %q", lp)
+		}
+
+		labels[k] = v
+	}
+
+	return id, labels, nil
 }

--- a/internal/http/backend/model/model_test.go
+++ b/internal/http/backend/model/model_test.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSLOGroupLabelsIDMarshal(t *testing.T) {
+	tests := map[string]struct {
+		sloID  string
+		labels map[string]string
+		expID  string
+	}{
+		"Marshalling grouped labels into the SLO ID should be marshaled correctly.": {
+			sloID: "test1",
+			labels: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+			expID: "test1:azE9djEsazI9djI=",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			id := SLOGroupLabelsIDMarshal(tc.sloID, tc.labels)
+			assert.Equal(tc.expID, id)
+		})
+	}
+}
+
+func TestSLOGroupLabelsIDUnmarshal(t *testing.T) {
+	tests := map[string]struct {
+		id        string
+		expSLOID  string
+		expLabels map[string]string
+		expErr    bool
+	}{
+		"A id with labels should return the information.": {
+			id:       "test1:azE9djEsazI9djI=",
+			expSLOID: "test1",
+			expLabels: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+			expErr: false,
+		},
+
+		"A id without labels should return the information.": {
+			id:       "test1",
+			expSLOID: "test1",
+			expErr:   false,
+		},
+
+		"A id with incorrect labels should fail.": {
+			id:     "test1:dsadasdasdsa",
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			sloID, labels, err := SLOGroupLabelsIDUnmarshal(test.id)
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				assert.Equal(test.expSLOID, sloID)
+				assert.Equal(test.expLabels, labels)
+			}
+		})
+	}
+}

--- a/internal/http/backend/storage/search/search.go
+++ b/internal/http/backend/storage/search/search.go
@@ -71,8 +71,14 @@ func (s SearchRepositoryWrapper) ListSLOInstantDetailsServiceBySLOSearch(ctx con
 	indexed := map[string]*storage.SLOInstantDetails{}
 	sloIDs := []string{}
 	for _, slo := range slos {
-		indexed[slo.SLO.ID] = &slo
-		sloIDs = append(sloIDs, slo.SLO.ID)
+		id := slo.SLO.ID
+		// Add group label values to the searchable ID.
+		for _, v := range slo.SLO.GroupLabels {
+			id += v
+		}
+
+		indexed[id] = &slo
+		sloIDs = append(sloIDs, id)
 	}
 
 	matches := find(sloSearchInput, sloIDs)
@@ -101,8 +107,14 @@ func (s SearchRepositoryWrapper) ListSLOInstantDetailsBySLOSearch(ctx context.Co
 	indexed := map[string]*storage.SLOInstantDetails{}
 	sloIDs := []string{}
 	for _, slo := range slos {
-		indexed[slo.SLO.ID] = &slo
-		sloIDs = append(sloIDs, slo.SLO.ID)
+		id := slo.SLO.ID
+		// Add group label values to the searchable ID.
+		for _, v := range slo.SLO.GroupLabels {
+			id += v
+		}
+
+		indexed[id] = &slo
+		sloIDs = append(sloIDs, id)
 	}
 
 	matches := find(sloSearchInput, sloIDs)

--- a/internal/http/backend/storage/search/search_test.go
+++ b/internal/http/backend/storage/search/search_test.go
@@ -30,6 +30,7 @@ func TestSearchRepositoryWrapperListServiceAndAlertsByServiceSearch(t *testing.T
 					{Service: model.Service{ID: "unrelated"}},
 					{Service: model.Service{ID: "service-mt-2"}},
 					{Service: model.Service{ID: "service-z"}},
+					{Service: model.Service{ID: "service-z"}},
 				}, nil)
 			},
 			expRes: []storage.ServiceAndAlerts{
@@ -95,12 +96,14 @@ func TestSearchRepositoryWrapperListSLOInstantDetailsServiceBySLOSearch(t *testi
 					{SLO: model.SLO{ID: "unrelated"}},
 					{SLO: model.SLO{ID: "service-mt-2"}},
 					{SLO: model.SLO{ID: "service-z"}},
+					{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 				}, nil)
 			},
 			expRes: []storage.SLOInstantDetails{
 				{SLO: model.SLO{ID: "service-mt"}},
 				{SLO: model.SLO{ID: "another-service-mt"}},
 				{SLO: model.SLO{ID: "service-mt-2"}},
+				{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 			},
 		},
 
@@ -115,6 +118,7 @@ func TestSearchRepositoryWrapperListSLOInstantDetailsServiceBySLOSearch(t *testi
 					{SLO: model.SLO{ID: "unrelated"}},
 					{SLO: model.SLO{ID: "service-mt-2"}},
 					{SLO: model.SLO{ID: "service-z"}},
+					{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 				}, nil)
 			},
 		},
@@ -160,12 +164,14 @@ func TestSearchRepositoryWrapperListSLOInstantDetailsBySLOSearch(t *testing.T) {
 					{SLO: model.SLO{ID: "unrelated"}},
 					{SLO: model.SLO{ID: "service-mt-2"}},
 					{SLO: model.SLO{ID: "service-z"}},
+					{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 				}, nil)
 			},
 			expRes: []storage.SLOInstantDetails{
 				{SLO: model.SLO{ID: "service-mt"}},
 				{SLO: model.SLO{ID: "another-service-mt"}},
 				{SLO: model.SLO{ID: "service-mt-2"}},
+				{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 			},
 		},
 
@@ -179,6 +185,7 @@ func TestSearchRepositoryWrapperListSLOInstantDetailsBySLOSearch(t *testing.T) {
 					{SLO: model.SLO{ID: "unrelated"}},
 					{SLO: model.SLO{ID: "service-mt-2"}},
 					{SLO: model.SLO{ID: "service-z"}},
+					{SLO: model.SLO{ID: "service-z2", GroupLabels: map[string]string{"env": "prod-mt"}}},
 				}, nil)
 			},
 		},

--- a/internal/http/ui/handler_select_slo.go
+++ b/internal/http/ui/handler_select_slo.go
@@ -26,6 +26,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 		ServiceURL                   string
 		CriticalAlertName            string
 		WarningAlertName             string
+		GroupLabels                  map[string]string
 	}
 
 	type tplData struct {
@@ -55,6 +56,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 				CriticalAlertName:            critAlert,
 				WarningAlertName:             warnAlert,
 				ServiceURL:                   urls.AppURL("/services/" + slo.SLO.ServiceID),
+				GroupLabels:                  slo.SLO.GroupLabels,
 			})
 		}
 		return slos

--- a/internal/http/ui/handler_select_slo_test.go
+++ b/internal/http/ui/handler_select_slo_test.go
@@ -67,10 +67,17 @@ func TestHandlerSelectSLO(t *testing.T) {
 						},
 						{
 							SLO: model.SLO{
-								ID:        "test-svc3-slo3",
+								ID:        "test-svc3-slo3:test-grouped",
+								SlothID:   "test-svc3-slo3",
 								ServiceID: "test-svc3",
 								Name:      "Test SLO 3",
+								IsGrouped: true,
+								GroupLabels: map[string]string{
+									"operation": "create",
+									"env":       "prod",
+								},
 							},
+							Alerts: model.SLOAlerts{},
 							Budget: model.SLOBudgetDetails{
 								SLOID:                     "test-svc3-slo3",
 								BurningBudgetPercent:      30.0,
@@ -87,13 +94,13 @@ func TestHandlerSelectSLO(t *testing.T) {
 			expBody: []string{
 				`<!DOCTYPE html>`,               // We rendered a full page.
 				`<div class="container"> <nav>`, // We have the menu.
-				`<input type="search" name="slo-search" value="" placeholder="Search" aria-label="Search" hx-get="/u/app/slos?component=slo-list" hx-trigger="change, keyup changed delay:500ms, search" hx-target="#slo-list" hx-include="this" />`, // We have the search bar with HTMX.
-				`<tr> <th scope="col">SLO</th> <th scope="col">Service</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th> </tr>`,                                                    // We have the slos table.
-				`<td><a href="/u/app/slos/test-svc1-slo1">Test SLO 1</td> <td><a href="/u/app/services/test-svc1">test-svc1</td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`,           // SLO1 should be critical.
-				`<td><a href="/u/app/slos/test-svc2-slo2">Test SLO 2</td> <td><a href="/u/app/services/test-svc2">test-svc2</td> <td class="is-ok">45%</td> <td class="is-ok">50%</td> <td> <div class="is-critical">Critical</div> </td>`,           // SLO2 should be warning.
-				`<td><a href="/u/app/slos/test-svc3-slo3">Test SLO 3</td> <td><a href="/u/app/services/test-svc3">test-svc3</td> <td class="is-ok">30%</td> <td class="is-ok">65%</td> <td> <div>-</div> </td>`,                                      // SLO3 should be ok.
-				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                // We have the pagination prev.
-				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                     // We have the pagination next.
+				`<input type="search" name="slo-search" value="" placeholder="Search" aria-label="Search" hx-get="/u/app/slos?component=slo-list" hx-trigger="change, keyup changed delay:500ms, search" hx-target="#slo-list" hx-include="this" />`,                                                                                                                                               // We have the search bar with HTMX.
+				`<tr> <th scope="col">SLO</th> <th scope="col">Service</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th> </tr>`,                                                                                                                                                                                                  // We have the slos table.
+				`<td> <a href="/u/app/slos/test-svc1-slo1">Test SLO 1</a> </td> <td><a href="/u/app/services/test-svc1">test-svc1</a></td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`,                                                                                                                                               // SLO1 should be critical.
+				`<td> <a href="/u/app/slos/test-svc2-slo2">Test SLO 2</a> </td> <td><a href="/u/app/services/test-svc2">test-svc2</a></td> <td class="is-ok">45%</td> <td class="is-ok">50%</td> <td> <div class="is-critical">Critical</div> </td>`,                                                                                                                                               // SLO2 should be warning.
+				`<td> <a href="/u/app/slos/test-svc3-slo3:test-grouped">Test SLO 3</a> <div><small><mark>env=<strong>prod</strong></mark></small> <span> </span><small><mark>operation=<strong>create</strong></mark></small> <span> </span></div> </td> <td><a href="/u/app/services/test-svc3">test-svc3</a></td> <td class="is-ok">30%</td> <td class="is-ok">65%</td> <td> <div>-</div> </td>`, // SLO3 should be ok and grouped.
+				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                                                                                                                                                              // We have the pagination prev.
+				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                                                                                                                                                                   // We have the pagination next.
 			},
 		},
 
@@ -138,9 +145,9 @@ func TestHandlerSelectSLO(t *testing.T) {
 			},
 			expCode: 200,
 			expBody: []string{
-				`<td><a href="/u/app/slos/test-svc1-slo1">Test SLO 1</td> <td><a href="/u/app/services/test-svc1">test-svc1</td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
-				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                      // We have the pagination prev.
-				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                                                               // We have the pagination next.
+				`<td> <a href="/u/app/slos/test-svc1-slo1">Test SLO 1</a> </td> <td><a href="/u/app/services/test-svc1">test-svc1</a></td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
+				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                // We have the pagination prev.
+				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                                                                         // We have the pagination next.
 			},
 		},
 
@@ -184,9 +191,9 @@ func TestHandlerSelectSLO(t *testing.T) {
 			},
 			expCode: 200,
 			expBody: []string{
-				`<td><a href="/u/app/slos/test-svc1-slo1">Test SLO 1</td> <td><a href="/u/app/services/test-svc1">test-svc1</td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
-				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                                                           // We have the pagination prev.
-				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                           // We have the pagination next.
+				`<td> <a href="/u/app/slos/test-svc1-slo1">Test SLO 1</a> </td> <td><a href="/u/app/services/test-svc1">test-svc1</a></td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
+				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                                                                     // We have the pagination prev.
+				`<button class="secondary" hx-get="/u/app/slos?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                     // We have the pagination next.
 			},
 		},
 
@@ -232,9 +239,9 @@ func TestHandlerSelectSLO(t *testing.T) {
 			},
 			expCode: 200,
 			expBody: []string{
-				`<td><a href="/u/app/slos/test-svc1-slo1">Test SLO 1</td> <td><a href="/u/app/services/test-svc1">test-svc1</td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
-				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                      // We have the pagination prev.
-				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                           // We have the pagination next.
+				`<td> <a href="/u/app/slos/test-svc1-slo1">Test SLO 1</a> </td> <td><a href="/u/app/services/test-svc1">test-svc1</a></td> <td class="is-ok">75%</td> <td class="is-ok">20%</td> <td> <div class="is-critical">Critical</div> </td>`, // SLO row should be ok.
+				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                // We have the pagination prev.
+				`<button class="secondary" hx-get="/u/app/slos?slo-search=test&component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                     // We have the pagination next.
 			},
 		},
 

--- a/internal/http/ui/handler_service_details.go
+++ b/internal/http/ui/handler_service_details.go
@@ -22,6 +22,7 @@ func (u ui) handlerServiceDetails() http.HandlerFunc {
 		DetailsURL                   string
 		CriticalAlertName            string
 		WarningAlertName             string
+		GroupLabels                  map[string]string
 	}
 
 	type tplData struct {
@@ -50,6 +51,7 @@ func (u ui) handlerServiceDetails() http.HandlerFunc {
 				DetailsURL:                   urls.AppURL("/slos/" + slo.SLO.ID),
 				CriticalAlertName:            critAlert,
 				WarningAlertName:             warnAlert,
+				GroupLabels:                  slo.SLO.GroupLabels,
 			})
 		}
 		return slos

--- a/internal/http/ui/handler_service_details_test.go
+++ b/internal/http/ui/handler_service_details_test.go
@@ -69,6 +69,25 @@ func TestHandlerServiceDetails(t *testing.T) {
 								FiringPage: &model.Alert{Name: "slo-2-critical"},
 							},
 						},
+						{
+							SLO: model.SLO{
+								ID:        "test-svc3-slo3:test-grouped",
+								SlothID:   "test-svc3-slo3",
+								ServiceID: "svc-1",
+								Name:      "Test SLO 3",
+								IsGrouped: true,
+								GroupLabels: map[string]string{
+									"operation": "create",
+									"env":       "prod",
+								},
+							},
+							Alerts: model.SLOAlerts{},
+							Budget: model.SLOBudgetDetails{
+								SLOID:                     "test-svc3-slo3",
+								BurningBudgetPercent:      30.0,
+								BurnedBudgetWindowPercent: 35.0,
+							},
+						},
 					},
 				}, nil)
 			},
@@ -80,11 +99,12 @@ func TestHandlerServiceDetails(t *testing.T) {
 				`<!DOCTYPE html>`,               // We rendered a full page.
 				`<div class="container"> <nav>`, // We have the menu.
 				`<h1>Service svc-1 </h1>`,       // We have the service title.
-				`<table> <thead> <tr> <th scope="col">SLO</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th>`,                                  // We have the SLOs table.
-				`<td><a href="/u/app/slos/slo-1">SLO 1</td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                           // We have the SLO 1 row.
-				`<td><a href="/u/app/slos/slo-2">SLO 2</td> <td class="is-ok">50%</td> <td class="is-warning">2%</td> <td> <div class="is-critical">Critical</div> </td>`,                                       // We have the SLO 2 row.
-				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`, // We have the pagination next.
-				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,      // We have the pagination prev.
+				`<table> <thead> <tr> <th scope="col">SLO</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th>`,                                                                                                                                                        // We have the SLOs table.
+				`<td> <a href="/u/app/slos/slo-1">SLO 1</a> </td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                                                                                                                                           // We have the SLO 1 row.
+				`<td> <a href="/u/app/slos/slo-2">SLO 2</a> </td> <td class="is-ok">50%</td> <td class="is-warning">2%</td> <td> <div class="is-critical">Critical</div> </td>`,                                                                                                                                                       // We have the SLO 2 row.
+				`<td> <a href="/u/app/slos/test-svc3-slo3:test-grouped">Test SLO 3</a> <div><small><mark>env=<strong>prod</strong></mark></small> <span></span><small><mark>operation=<strong>create</strong></mark></small> <span></span></div> </td> <td class="is-ok">30%</td> <td class="is-ok">65%</td> <td> <div>-</div> </td>`, // We have the SLO 3 row with grouped SLO.
+				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                                                                                       // We have the pagination next.
+				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                                                                                            // We have the pagination prev.
 			},
 		},
 
@@ -131,7 +151,7 @@ func TestHandlerServiceDetails(t *testing.T) {
 			expCode: 200,
 			expBody: []string{
 				`<table> <thead> <tr> <th scope="col">SLO</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th>`,                                 // We have the SLOs table.
-				`<td><a href="/u/app/slos/slo-1">SLO 1</td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                          // We have the SLO 1 row.
+				`<td> <a href="/u/app/slos/slo-1">SLO 1</a> </td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                    // We have the SLO 1 row.
 				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&backward-cursor=test-prev-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button`, // We have the pagination next.
 				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`,                                                                   // We have the pagination prev.
 			},
@@ -180,7 +200,7 @@ func TestHandlerServiceDetails(t *testing.T) {
 			expCode: 200,
 			expBody: []string{
 				`<table> <thead> <tr> <th scope="col">SLO</th> <th scope="col">Burning budget</th> <th scope="col">Remaining budget (Window)</th> <th scope="col">Alerts</th>`,                             // We have the SLOs table.
-				`<td><a href="/u/app/slos/slo-1">SLO 1</td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                      // We have the SLO 1 row.
+				`<td> <a href="/u/app/slos/slo-1">SLO 1</a> </td> <td class="is-ok">23.5%</td> <td class="is-ok">90%</td> <td> <div class="is-warning">Warning</div> </td>`,                                // We have the SLO 1 row.
 				`<button class="secondary"  disabled hx-get="" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> << Previous </button>`,                                                           // We have the pagination next.
 				`<button class="secondary" hx-get="/u/app/services/svc-1?component=slo-list&forward-cursor=test-next-cursor" hx-target="#slo-list" hx-swap="innerHTML show:window:top"> Next >> </button>`, // We have the pagination prev.
 			},

--- a/internal/http/ui/handler_slo_details.go
+++ b/internal/http/ui/handler_slo_details.go
@@ -75,6 +75,7 @@ func (u ui) handlerSLODetails() http.HandlerFunc {
 		CriticalAlertName            string
 		WarningAlertName             string
 		RefreshURL                   string
+		GroupLabels                  map[string]string
 	}
 
 	type tplData struct {
@@ -102,6 +103,7 @@ func (u ui) handlerSLODetails() http.HandlerFunc {
 			RemainingBudgetWindowPercent: 100 - s.Budget.BurnedBudgetWindowPercent,
 			CriticalAlertName:            critAlert,
 			WarningAlertName:             warnAlert,
+			GroupLabels:                  s.SLO.GroupLabels,
 		}
 	}
 

--- a/internal/http/ui/handler_slo_details_test.go
+++ b/internal/http/ui/handler_slo_details_test.go
@@ -30,10 +30,16 @@ func TestHandlerSLODetails(t *testing.T) {
 				m.ServiceApp.On("GetSLO", mock.Anything, expReq1).Return(&app.GetSLOResponse{
 					SLO: app.RealTimeSLODetails{
 						SLO: model.SLO{
-							ID:        "slo-1",
+							ID:        "slo-1:test-grouped",
+							SlothID:   "slo-1",
 							Name:      "SLO 1",
 							ServiceID: "svc-1",
 							Objective: 99.9,
+							IsGrouped: true,
+							GroupLabels: map[string]string{
+								"operation": "create",
+								"type":      "something",
+							},
 						},
 						Budget: model.SLOBudgetDetails{
 							SLOID:                     "slo-1",
@@ -88,6 +94,9 @@ func TestHandlerSLODetails(t *testing.T) {
 				`<!DOCTYPE html>`,               // We rendered a full page.
 				`<div class="container"> <nav>`, // We have the menu.
 				`<h1> <a href="/u/app/services/svc-1">svc-1</a> / SLO 1</h1>`, // We have the SLO title with service link.
+
+				// Grouped SLO info.
+				`<div><mark>operation: <strong>create</strong></mark> <span> </span><mark>type: <strong>something</strong></mark> <span> </span></div>`,
 
 				// Stats.
 				`<div class="grid stats" hx-trigger="every 30s" hx-get="/u/app/slos/slo-1?component=slo-stats" hx-swap="outerHTML">`,                                                           // Autoreload status with HTMX.

--- a/internal/http/ui/routes.go
+++ b/internal/http/ui/routes.go
@@ -26,7 +26,7 @@ func (u ui) registerRoutes() {
 	u.wrapGet(URLPathAppPrefix+"/services", u.handlerSelectService())
 	u.wrapGet(URLPathAppPrefix+"/slos", u.handlerSelectSLO())
 	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/services/{%s:%s}", URLParamServiceID, conventions.NameRegexpStr), u.handlerServiceDetails())
-	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/slos/{%s:%s}", URLParamSLOID, conventions.NameRegexpStr), u.handlerSLODetails())
+	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/slos/{%s:%s}", URLParamSLOID, ".*"), u.handlerSLODetails())
 }
 
 func (u ui) wrapGet(pattern string, h http.HandlerFunc) {

--- a/internal/http/ui/templates/app/service/comp_slo_list.tmpl
+++ b/internal/http/ui/templates/app/service/comp_slo_list.tmpl
@@ -17,7 +17,17 @@
     <tbody>
         {{range .Data.SLOs}}
         <tr>
-        <td><a href="{{.DetailsURL}}">{{.Name}}</td>
+        <td>
+            <a href="{{.DetailsURL}}">{{.Name}}</a>
+            {{ if .GroupLabels }}
+            <div>
+            {{- range $key, $value := .GroupLabels -}}
+                <small><mark>{{ $key }}=<strong>{{ $value }}</strong></mark></small>
+                <span></span>
+            {{- end -}}
+            </div>
+            {{ end }}
+        </td>
         <td class="{{.BurningBudgetPercent | percentUpColorCSSClass}}">{{.BurningBudgetPercent | prettyPercent}}</td>
         <td class="{{.RemainingBudgetWindowPercent | percentDownColorCSSClass}}">{{.RemainingBudgetWindowPercent | prettyPercent}}</td>
         <td>

--- a/internal/http/ui/templates/app/slo/page.tmpl
+++ b/internal/http/ui/templates/app/slo/page.tmpl
@@ -7,6 +7,12 @@
 {{template "shared_nav" .}}
 <main class="container">
 <h1> <a href="{{.Data.SLOData.ServiceURL}}">{{.Data.SLOData.ServiceID}}</a> / {{.Data.SLOData.Name}}</h1>
+<div>
+{{- range $key, $value := .Data.SLOData.GroupLabels -}}
+    <mark>{{ $key }}: <strong>{{ $value }}</strong></mark>
+    <span> </span>
+{{- end -}}
+</div>
 <br />
 {{template "app_slo_comp_slo_data" .}}
 </main>

--- a/internal/http/ui/templates/app/slos/comp_slo_list.tmpl
+++ b/internal/http/ui/templates/app/slos/comp_slo_list.tmpl
@@ -18,8 +18,18 @@
     <tbody>
         {{range .Data.SLOs}}
         <tr>
-        <td><a href="{{.DetailsURL}}">{{.Name}}</td>
-        <td><a href="{{.ServiceURL}}">{{.ServiceID}}</td>
+        <td>
+            <a href="{{.DetailsURL}}">{{.Name}}</a>
+            {{ if .GroupLabels }}
+            <div>
+                {{- range $key, $value := .GroupLabels -}}
+                    <small><mark>{{ $key }}=<strong>{{ $value }}</strong></mark></small>
+                    <span> </span>
+                {{- end -}}
+            </div>
+            {{ end }}
+        </td>
+        <td><a href="{{.ServiceURL}}">{{.ServiceID}}</a></td>
         <td class="{{.BurningBudgetPercent | percentUpColorCSSClass}}">{{.BurningBudgetPercent | prettyPercent}}</td>
         <td class="{{.RemainingBudgetWindowPercent | percentDownColorCSSClass}}">{{.RemainingBudgetWindowPercent | prettyPercent}}</td>
         <td>


### PR DESCRIPTION
This PR adds a new feature that has been asked for years 🚀. Until now that we didn't have the ability to control the visualization we couldn't do anything in Grafana, as inferring dynamic labels its very difficult when you need special logic.

Currently The sloth spec doesn't have a way of telling if a SLO is grouped or not (e.g: Pyrra has), however this isn't required, the SLI PromQL queries can aggregate by grouping labels. The generated rules will work, like the alerts. However like we said the visualization in Grafana breaks.

This PR adds suppor for this grouped labels SLOs on the new Sloth UI

## Inferring SLO group labels

In this PR we add support for SLO group label inference, the process is bit complex, in a few words this is the process:
1.  Get the SLO labels from the info metadata metric.
2. Get the SLI recorded labels (these have the grouped ones set in the SLI query).
3. Remove the SLO labels (step `1.`)  from the SLI labels (step `2. `) to get the SLO group labels.
4. From now on, we can get all the metrics without aggregation and match with the SLO group labels (step 3.).

## Handling SLO

For the UI, an SLO is unique, so the same SLO with different group labels (if it has) will be different SLOs in our UI domain layer. For this purpose, now, the UI backend and frontend understands 2 types of IDs:
* `SlothID`: The SLO Id from the spec (service name + slo name), normally seen on the metrics as the label `sloth_id`.
* `SLOID`: The unique ID of the SLO.
	* On non grouped SLOs it will be the same as the SlothID. Eg: `coredns-dns-latency`
	* On grouped SLOs it will be the SlothID + hash of group labels. E.g: `etcd-midgard-operation-request-latency:b3BlcmF0aW9uPWNyZWF0ZSx0eXBlPWF1dGhyZXF1ZXN0cy5kZXguY29yZW9zLmNvbQ==`

## Interaction

As stated in the previous section, for the UI, grouped or not, SLOs must be unique, so a grouped SLO with specific labels it will be listed, paginated, searched and filtered as a regular SLO. For the fuzzy search, the SLO label values will be added to the indexed search string.

## Bottlenecks

This it may increase the SLO quantity exponentially, so, a way of filtering it may need to be added in the future. For now until we gather more feedback, deliver with the simplest approach.

## Examples

### Details of grouped SLO

<img width="1495" height="870" alt="Screenshot 2025-11-22 at 11 22 55" src="https://github.com/user-attachments/assets/049b0bab-7a3b-4622-a1bf-77e6df77385d" />


### List of grouped SLOS

#### Spec of the example

```yaml

---
apiVersion: sloth.slok.dev/v1
kind: PrometheusServiceLevel
metadata:
  name: sloth-slo-etcd
  labels:
    prometheus: prometheus
    role: alert-rules
    app: sloth
spec:
  service: "etcd-midgard"
  labels:
    cluster: "midgard"
    context: "home"
  slos:
    - name: "operation-request-latency"
      objective: 90
      sli:
        events:
          errorQuery: |
            (
              sum(rate(etcd_request_duration_seconds_count{}[{{.window}}])) by(operation, type)
              -
              sum(rate(etcd_request_duration_seconds_bucket{le="0.005"}[{{.window}}])) by(operation, type)
            )
          totalQuery: sum(rate(etcd_request_duration_seconds_count{}[{{.window}}])) by(operation, type)
      alerting:
        pageAlert:
          disable: true
        ticketAlert:
          disable: true
```

#### UI of the example

<img width="1574" height="823" alt="Screenshot 2025-11-22 at 11 23 11" src="https://github.com/user-attachments/assets/9dc2ec57-ade0-49c3-b655-54571d72f658" />

### Search of grouped SLOs

<img width="1533" height="486" alt="Screenshot 2025-11-22 at 11 23 22" src="https://github.com/user-attachments/assets/079ab883-d211-4c75-a86f-5710d51dea0a" />

### List of grouped and non grouped SLOs

<img width="1505" height="453" alt="Screenshot 2025-11-22 at 11 26 22" src="https://github.com/user-attachments/assets/85c8e51b-0a7b-49d4-89d4-3c3afd85523a" />
