### PR TITLE
Add grouping label UI redirection to proper ID helper on the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - UI: SLO listing, searching and filtered by service.
 - UI: SLO details with stats, alerts state, SLI chart and budged burn in period chart.
 - UI: Support SLO grouped by labels.
+- UI: Redirect unmarshaled ID of grouped SLO labels to proper SLO ID.
 
 ### Changed
 

--- a/internal/http/backend/app/time_utils.go
+++ b/internal/http/backend/app/time_utils.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/slok/sloth/internal/http/backend/model"
@@ -32,7 +33,8 @@ func sanitizeDataPoints(dps []model.DataPoint, from, to time.Time, step time.Dur
 	sanitizedDPs := []model.DataPoint{}
 	for ts := from; ts.Before(to); ts = ts.Add(step) {
 		unixTS := ts.Unix()
-		if dp, exists := dpMap[unixTS]; exists {
+		dp, exists := dpMap[unixTS]
+		if exists && !math.IsNaN(dp.Value) {
 			sanitizedDPs = append(sanitizedDPs, dp)
 		} else {
 			sanitizedDPs = append(sanitizedDPs, model.DataPoint{
@@ -107,7 +109,7 @@ func endOfPeriod(t time.Time, periodType BudgetRangeType) (time.Time, error) {
 
 func sanitizeDataPointsUntilEndPeriod(dps []model.DataPoint, periodType BudgetRangeType) ([]model.DataPoint, error) {
 	if len(dps) < 2 {
-		return nil, fmt.Errorf("not enough data points to fill time range")
+		return []model.DataPoint{}, nil
 	}
 
 	// Get the step.

--- a/internal/http/backend/storage/prometheus/cache.go
+++ b/internal/http/backend/storage/prometheus/cache.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -361,7 +362,11 @@ func (r *Repository) listSLOBurningCurrentRatio(ctx context.Context, sloGrouping
 			sloID = model.SLOGroupLabelsIDMarshal(slothID, groupedLabels)
 		}
 
-		burnRates[sloID] = float64(sample.Value)
+		v := float64(sample.Value)
+		if math.IsNaN(v) {
+			v = 0
+		}
+		burnRates[sloID] = v
 	}
 
 	return burnRates, nil

--- a/internal/http/ui/handler_select_service.go
+++ b/internal/http/ui/handler_select_service.go
@@ -103,6 +103,7 @@ func (u ui) handlerSelectService() http.HandlerFunc {
 				Cursor:            nextCursor,
 			})
 			if err != nil {
+				u.logger.Errorf("could not list services: %s", err)
 				http.Error(w, "could not list services", http.StatusInternalServerError)
 				return
 			}
@@ -119,6 +120,7 @@ func (u ui) handlerSelectService() http.HandlerFunc {
 				Cursor:            prevCursor,
 			})
 			if err != nil {
+				u.logger.Errorf("could not list services: %s", err)
 				http.Error(w, "could not list services", http.StatusInternalServerError)
 				return
 			}
@@ -132,6 +134,7 @@ func (u ui) handlerSelectService() http.HandlerFunc {
 		case isHTMXCall && component == componentServiceList:
 			resp, err := u.serviceApp.ListServices(ctx, app.ListServicesRequest{FilterSearchInput: data.ServiceSearchInput})
 			if err != nil {
+				u.logger.Errorf("could not list services: %s", err)
 				http.Error(w, "could not list services", http.StatusInternalServerError)
 				return
 			}
@@ -149,6 +152,7 @@ func (u ui) handlerSelectService() http.HandlerFunc {
 		default:
 			resp, err := u.serviceApp.ListServices(ctx, app.ListServicesRequest{FilterSearchInput: data.ServiceSearchInput})
 			if err != nil {
+				u.logger.Errorf("could not list services: %s", err)
 				http.Error(w, "could not list services", http.StatusInternalServerError)
 				return
 			}

--- a/internal/http/ui/handler_select_slo.go
+++ b/internal/http/ui/handler_select_slo.go
@@ -89,6 +89,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 				FilterSearchInput: data.SLOSearchInput,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get SLOs: %s", err)
 				http.Error(w, "could not get SLOs", http.StatusInternalServerError)
 				return
 			}
@@ -106,6 +107,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 				FilterSearchInput: data.SLOSearchInput,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get SLOs: %s", err)
 				http.Error(w, "could not get SLOs", http.StatusInternalServerError)
 				return
 			}
@@ -122,6 +124,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 				FilterSearchInput: data.SLOSearchInput,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get SLOs: %s", err)
 				http.Error(w, "could not get SLOs", http.StatusInternalServerError)
 				return
 			}
@@ -142,6 +145,7 @@ func (u ui) handlerSelectSLO() http.HandlerFunc {
 				FilterSearchInput: data.SLOSearchInput,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get SLOs: %s", err)
 				http.Error(w, "could not get SLOs", http.StatusInternalServerError)
 				return
 			}

--- a/internal/http/ui/handler_service_details.go
+++ b/internal/http/ui/handler_service_details.go
@@ -81,6 +81,7 @@ func (u ui) handlerServiceDetails() http.HandlerFunc {
 				Cursor:          nextCursor,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get service SLOs: %s", err)
 				http.Error(w, "could not get service SLOs", http.StatusInternalServerError)
 				return
 			}
@@ -98,6 +99,7 @@ func (u ui) handlerServiceDetails() http.HandlerFunc {
 				Cursor:          prevCursor,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get service SLOs: %s", err)
 				http.Error(w, "could not get service SLOs", http.StatusInternalServerError)
 				return
 			}
@@ -118,6 +120,7 @@ func (u ui) handlerServiceDetails() http.HandlerFunc {
 				FilterServiceID: data.ServiceID,
 			})
 			if err != nil {
+				u.logger.Errorf("could not get service SLOs: %s", err)
 				http.Error(w, "could not get service SLOs", http.StatusInternalServerError)
 				return
 			}

--- a/internal/http/ui/handler_slo_details_test.go
+++ b/internal/http/ui/handler_slo_details_test.go
@@ -21,6 +21,54 @@ func TestHandlerSLODetails(t *testing.T) {
 		expHeaders http.Header
 		expCode    int
 	}{
+		"Grouped SLO IDs using unmarshaled group labels should be redirected to the marshaled ID endpoint.": {
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/u/app/slos/etcd-midgard-operation-request-latency?group-labels={operation=create,type=authrequests.dex.coreos.com}", nil)
+			},
+			mock: func(m mocks) {},
+			expHeaders: http.Header{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Location":     {"/u/app/slos/etcd-midgard-operation-request-latency:b3BlcmF0aW9uPWNyZWF0ZSx0eXBlPWF1dGhyZXF1ZXN0cy5kZXguY29yZW9zLmNvbQ=="},
+			},
+			expCode: 307,
+		},
+
+		"Grouped SLO IDs using unmarshaled group labels should be redirected to the marshaled ID endpoint (unordered labels).": {
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/u/app/slos/etcd-midgard-operation-request-latency?group-labels={type=authrequests.dex.coreos.com,operation=create}", nil)
+			},
+			mock: func(m mocks) {},
+			expHeaders: http.Header{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Location":     {"/u/app/slos/etcd-midgard-operation-request-latency:b3BlcmF0aW9uPWNyZWF0ZSx0eXBlPWF1dGhyZXF1ZXN0cy5kZXguY29yZW9zLmNvbQ=="},
+			},
+			expCode: 307,
+		},
+
+		"Grouped SLO IDs using unmarshaled group labels should be redirected to the marshaled ID endpoint (special characters).": {
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/u/app/slos/etcd-midgard-operation-request-latency?group-labels={path=/something}", nil)
+			},
+			mock: func(m mocks) {},
+			expHeaders: http.Header{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Location":     {"/u/app/slos/etcd-midgard-operation-request-latency:cGF0aD0vc29tZXRoaW5n"},
+			},
+			expCode: 307,
+		},
+
+		"Grouped SLO IDs using unmarshaled group labels should be redirected to the marshaled ID endpoint (HTTP special characters).": {
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/u/app/slos/etcd-midgard-operation-request-latency?group-labels=%7Boperation=create,type=authrequests.dex.coreos.com%7D", nil)
+			},
+			mock: func(m mocks) {},
+			expHeaders: http.Header{
+				"Content-Type": {"text/html; charset=utf-8"},
+				"Location":     {"/u/app/slos/etcd-midgard-operation-request-latency:b3BlcmF0aW9uPWNyZWF0ZSx0eXBlPWF1dGhyZXF1ZXN0cy5kZXguY29yZW9zLmNvbQ=="},
+			},
+			expCode: 307,
+		},
+
 		"Listing the SLO details should render the full page.": {
 			request: func() *http.Request {
 				return httptest.NewRequest(http.MethodGet, "/u/app/slos/slo-1", nil)

--- a/internal/http/ui/routes.go
+++ b/internal/http/ui/routes.go
@@ -15,6 +15,10 @@ const (
 	URLParamSLOID     = "sloID"
 )
 
+const (
+	sloIDRegexStr = `[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9](:[a-zA-Z0-9\-\+_=]+)?`
+)
+
 func (u ui) registerStaticFilesRoutes() {
 	u.staticFilesRouter.Handle("/*", http.StripPrefix(ServePrefix, http.FileServer(http.FS(staticFS))))
 }
@@ -26,7 +30,7 @@ func (u ui) registerRoutes() {
 	u.wrapGet(URLPathAppPrefix+"/services", u.handlerSelectService())
 	u.wrapGet(URLPathAppPrefix+"/slos", u.handlerSelectSLO())
 	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/services/{%s:%s}", URLParamServiceID, conventions.NameRegexpStr), u.handlerServiceDetails())
-	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/slos/{%s:%s}", URLParamSLOID, ".*"), u.handlerSLODetails())
+	u.wrapGet(URLPathAppPrefix+fmt.Sprintf("/slos/{%s:%s}", URLParamSLOID, sloIDRegexStr), u.handlerSLODetails())
 }
 
 func (u ui) wrapGet(pattern string, h http.HandlerFunc) {


### PR DESCRIPTION
This PR adds a helper URL util on the UI. Now that we supported grouped SLOs and they have an special ID that is marshaled, we add a URL helper that redirect properly to the SLO grouped ID URL. Example:

* URL: `/u/app/slos/etcd-midgard-operation-request-latency?group-labels={operation=create,type=authrequests.dex.coreos.com}`
* Redirected URL: `/u/app/slos/etcd-midgard-operation-request-latency:b3BlcmF0aW9uPWNyZWF0ZSx0eXBlPWF1dGhyZXF1ZXN0cy5kZXguY29yZW9zLmNvbQ==`