### PR TITLE
fix: don't walk dirs starting with ".." when loading plugins

### DIFF
--- a/internal/storage/fs/plugin.go
+++ b/internal/storage/fs/plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/slok/sloth/internal/log"
@@ -148,6 +149,9 @@ func (r *FilePluginRepo) loadPlugins(ctx context.Context, fss ...fs.FS) (map[str
 				return err
 			}
 			if d.IsDir() {
+				if strings.HasPrefix(d.Name(), "..") {
+					return fs.SkipDir
+				}
 				return nil
 			}
 

--- a/internal/storage/fs/plugin_test.go
+++ b/internal/storage/fs/plugin_test.go
@@ -39,6 +39,7 @@ func TestFilePluginRepoListSLOPlugins(t *testing.T) {
 				m1["m1/pl1/plugin.go"] = &fstest.MapFile{Data: []byte("p1")}
 				m1["m1/pl2/plugin.go"] = &fstest.MapFile{Data: []byte("p2")}
 				m1["m1/plx/pl3/plugin.go"] = &fstest.MapFile{Data: []byte("p3")}
+				m1["m1/..pl4/plugin.go"] = &fstest.MapFile{Data: []byte("p7")} // Ignored.
 
 				m2 := make(fstest.MapFS)
 				m2["m2/pl1/plugin.go"] = &fstest.MapFile{Data: []byte("p4")}
@@ -47,7 +48,7 @@ func TestFilePluginRepoListSLOPlugins(t *testing.T) {
 
 				m3 := make(fstest.MapFS)
 				m3["m3/plx/pl3/plugin.go"] = &fstest.MapFile{Data: []byte("p6")}
-				m3["m3/plx/pl3/plugin.yaml"] = &fstest.MapFile{Data: []byte("p7")} // Ignored.
+				m3["m3/plx/pl3/plugin.yaml"] = &fstest.MapFile{Data: []byte("p9")} // Ignored.
 
 				return []fs.FS{m1, m2, m3}
 			},


### PR DESCRIPTION
If using Kubernetes ConfigMaps as a volume mount in a container to manage custom plugins, a special directory structure is used to allow Kubernetes to update ConfigMap data atomically. I can't find any reference to this in the Kubernetes documentation, but it's best explained here: https://stackoverflow.com/questions/62776362/k8s-configmap-mounted-inside-symbolic-link-to-data-directory.

This directory structure and the symlinks used causes Sloth to attempt to load plugins more than once, as it descends the hidden directories that are prefixed with `..`, as well as reading symlinks.

This patch prevents the loadPlugins function from descending directories that start with `..`. This is potentially a breaking change for those who have plugins stored in directories starting with `..`, but I can't imagine that would common.