### PR TITLE
fix: block objective=100 and guard events SLI denominator against 0

### DIFF
--- a/internal/app/generate/generate_test.go
+++ b/internal/app/generate/generate_test.go
@@ -180,7 +180,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								Rules: []rulefmt.Rule{
 									{
 										Record: "slo:sli_error:ratio_rate5m",
-										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n((rate(my_metric[5m])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -193,7 +193,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate30m",
-										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n((rate(my_metric[30m])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -206,7 +206,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate1h",
-										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n((rate(my_metric[1h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -219,7 +219,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate2h",
-										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n((rate(my_metric[2h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -232,7 +232,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate6h",
-										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n((rate(my_metric[6h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -245,7 +245,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate1d",
-										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n((rate(my_metric[1d])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -258,7 +258,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 									},
 									{
 										Record: "slo:sli_error:ratio_rate3d",
-										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n((rate(my_metric[3d])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -593,7 +593,7 @@ or
 								Rules: []rulefmt.Rule{
 									{
 										Record: "slo:sli_error:ratio_rate5m",
-										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n(rate(my_metric[5m]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[5m]))\n/\n((rate(my_metric[5m])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -606,7 +606,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate30m",
-										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n(rate(my_metric[30m]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[30m]))\n/\n((rate(my_metric[30m])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -619,7 +619,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate1h",
-										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n(rate(my_metric[1h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[1h]))\n/\n((rate(my_metric[1h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -632,7 +632,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate2h",
-										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n(rate(my_metric[2h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[2h]))\n/\n((rate(my_metric[2h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -645,7 +645,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate6h",
-										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n(rate(my_metric[6h]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[6h]))\n/\n((rate(my_metric[6h])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -658,7 +658,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate1d",
-										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n(rate(my_metric[1d]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[1d]))\n/\n((rate(my_metric[1d])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",
@@ -671,7 +671,7 @@ or
 									},
 									{
 										Record: "slo:sli_error:ratio_rate3d",
-										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n(rate(my_metric[3d]))\n",
+										Expr:   "(rate(my_metric{error=\"true\"}[3d]))\n/\n((rate(my_metric[3d])) > 0)\n",
 										Labels: map[string]string{
 											"test_label":    "label_1",
 											"extra_k1":      "extra_v1",

--- a/internal/plugin/slo/core/sli_rules_v1/plugin.go
+++ b/internal/plugin/slo/core/sli_rules_v1/plugin.go
@@ -134,9 +134,11 @@ func rawSLIRecordGenerator(slo model.PromSLO, window time.Duration, alerts model
 }
 
 func eventsSLIRecordGenerator(slo model.PromSLO, window time.Duration, alerts model.MWMBAlertGroup) (*rulefmt.Rule, error) {
+	// Wrap the denominator with ((...) > 0) so a zero total produces an absent result
+	// rather than +Inf, which would otherwise poison sum_over_time for up to 30 days.
 	const sliExprTplFmt = `(%s)
 /
-(%s)
+((%s) > 0)
 `
 	// Generate our first level of template by assembling the error and total expressions.
 	sliExprTpl := fmt.Sprintf(sliExprTplFmt, slo.SLI.Events.ErrorQuery, slo.SLI.Events.TotalQuery)

--- a/internal/plugin/slo/core/sli_rules_v1/plugin_test.go
+++ b/internal/plugin/slo/core/sli_rules_v1/plugin_test.go
@@ -111,7 +111,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 			expRules: []rulefmt.Rule{
 				{
 					Record: "slo:sli_error:ratio_rate5m",
-					Expr:   "(rate(my_metric[5m]{error=\"true\"}))\n/\n(rate(my_metric[5m]))\n",
+					Expr:   "(rate(my_metric[5m]{error=\"true\"}))\n/\n((rate(my_metric[5m])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -122,7 +122,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30m",
-					Expr:   "(rate(my_metric[30m]{error=\"true\"}))\n/\n(rate(my_metric[30m]))\n",
+					Expr:   "(rate(my_metric[30m]{error=\"true\"}))\n/\n((rate(my_metric[30m])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -133,7 +133,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate1h",
-					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n(rate(my_metric[1h]))\n",
+					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n((rate(my_metric[1h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -144,7 +144,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate2h",
-					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n(rate(my_metric[2h]))\n",
+					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n((rate(my_metric[2h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -155,7 +155,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate6h",
-					Expr:   "(rate(my_metric[6h]{error=\"true\"}))\n/\n(rate(my_metric[6h]))\n",
+					Expr:   "(rate(my_metric[6h]{error=\"true\"}))\n/\n((rate(my_metric[6h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -166,7 +166,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate1d",
-					Expr:   "(rate(my_metric[1d]{error=\"true\"}))\n/\n(rate(my_metric[1d]))\n",
+					Expr:   "(rate(my_metric[1d]{error=\"true\"}))\n/\n((rate(my_metric[1d])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -177,7 +177,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate3d",
-					Expr:   "(rate(my_metric[3d]{error=\"true\"}))\n/\n(rate(my_metric[3d]))\n",
+					Expr:   "(rate(my_metric[3d]{error=\"true\"}))\n/\n((rate(my_metric[3d])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -221,7 +221,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 			expRules: []rulefmt.Rule{
 				{
 					Record: "slo:sli_error:ratio_rate5m",
-					Expr:   "(rate(my_metric[5m]{error=\"true\"}))\n/\n(rate(my_metric[5m]))\n",
+					Expr:   "(rate(my_metric[5m]{error=\"true\"}))\n/\n((rate(my_metric[5m])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -232,7 +232,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30m",
-					Expr:   "(rate(my_metric[30m]{error=\"true\"}))\n/\n(rate(my_metric[30m]))\n",
+					Expr:   "(rate(my_metric[30m]{error=\"true\"}))\n/\n((rate(my_metric[30m])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -243,7 +243,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate1h",
-					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n(rate(my_metric[1h]))\n",
+					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n((rate(my_metric[1h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -254,7 +254,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate2h",
-					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n(rate(my_metric[2h]))\n",
+					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n((rate(my_metric[2h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -265,7 +265,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate6h",
-					Expr:   "(rate(my_metric[6h]{error=\"true\"}))\n/\n(rate(my_metric[6h]))\n",
+					Expr:   "(rate(my_metric[6h]{error=\"true\"}))\n/\n((rate(my_metric[6h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -276,7 +276,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate1d",
-					Expr:   "(rate(my_metric[1d]{error=\"true\"}))\n/\n(rate(my_metric[1d]))\n",
+					Expr:   "(rate(my_metric[1d]{error=\"true\"}))\n/\n((rate(my_metric[1d])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -287,7 +287,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate3d",
-					Expr:   "(rate(my_metric[3d]{error=\"true\"}))\n/\n(rate(my_metric[3d]))\n",
+					Expr:   "(rate(my_metric[3d]{error=\"true\"}))\n/\n((rate(my_metric[3d])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -298,7 +298,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "(rate(my_metric[30d]{error=\"true\"}))\n/\n(rate(my_metric[30d]))\n",
+					Expr:   "(rate(my_metric[30d]{error=\"true\"}))\n/\n((rate(my_metric[30d])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -445,7 +445,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 			expRules: []rulefmt.Rule{
 				{
 					Record: "slo:sli_error:ratio_rate1h",
-					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n(rate(my_metric[1h]))\n",
+					Expr:   "(rate(my_metric[1h]{error=\"true\"}))\n/\n((rate(my_metric[1h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -456,7 +456,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate2h",
-					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n(rate(my_metric[2h]))\n",
+					Expr:   "(rate(my_metric[2h]{error=\"true\"}))\n/\n((rate(my_metric[2h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -467,7 +467,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate3h",
-					Expr:   "(rate(my_metric[3h]{error=\"true\"}))\n/\n(rate(my_metric[3h]))\n",
+					Expr:   "(rate(my_metric[3h]{error=\"true\"}))\n/\n((rate(my_metric[3h])) > 0)\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",

--- a/pkg/common/validation/slo.go
+++ b/pkg/common/validation/slo.go
@@ -162,8 +162,9 @@ func ValidateSLO(slo model.PromSLO, dialect SLODialectValidator) error {
 		return fmt.Errorf("time window is required")
 	}
 
-	if slo.Objective <= 0 || slo.Objective > 100 {
-		return fmt.Errorf("objective must >0 and <=100")
+	// Objective=100 yields a zero error budget, causing division by zero in burn rate calculations.
+	if slo.Objective <= 0 || slo.Objective >= 100 {
+		return fmt.Errorf("objective must >0 and <100")
 	}
 
 	for k, v := range slo.Labels {

--- a/pkg/common/validation/slo_test.go
+++ b/pkg/common/validation/slo_test.go
@@ -308,7 +308,7 @@ func TestModelValidationSpecForPrometheusBackend(t *testing.T) {
 				s.Objective = -1
 				return s
 			},
-			expErrMessage: `objective must >0 and <=100`,
+			expErrMessage: `objective must >0 and <100`,
 		},
 
 		"SLO Objective shouldn't be 0.": {
@@ -317,7 +317,16 @@ func TestModelValidationSpecForPrometheusBackend(t *testing.T) {
 				s.Objective = 0
 				return s
 			},
-			expErrMessage: `objective must >0 and <=100`,
+			expErrMessage: `objective must >0 and <100`,
+		},
+
+		"SLO Objective shouldn't be 100 because error budget would be zero causing infinite burn rates.": {
+			slo: func() model.PromSLO {
+				s := getGoodSLO()
+				s.Objective = 100
+				return s
+			},
+			expErrMessage: `objective must >0 and <100`,
 		},
 
 		"SLO Objective shouldn't be greater than 100.": {
@@ -326,7 +335,7 @@ func TestModelValidationSpecForPrometheusBackend(t *testing.T) {
 				s.Objective = 100.0001
 				return s
 			},
-			expErrMessage: `objective must >0 and <=100`,
+			expErrMessage: `objective must >0 and <100`,
 		},
 
 		"SLO Labels should be valid prometheus keys.": {

--- a/test/integration/prometheus/testdata/out-base-28d.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-28d.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-base-custom-windows-7d.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-custom-windows-7d.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-base-extra-labels.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-extra-labels.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -24,7 +24,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -38,7 +38,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -52,7 +52,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -66,7 +66,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -80,7 +80,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2
@@ -94,7 +94,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       exk1: exv1
       exk2: exv2

--- a/test/integration/prometheus/testdata/out-base-k8s.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-k8s.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -30,7 +30,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -42,7 +42,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -54,7 +54,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -66,7 +66,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -78,7 +78,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -90,7 +90,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-base.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-multifile-k8s.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-multifile-k8s.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -30,7 +30,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -42,7 +42,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -54,7 +54,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -66,7 +66,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -78,7 +78,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -90,7 +90,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -422,7 +422,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -434,7 +434,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -446,7 +446,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -458,7 +458,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -470,7 +470,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -482,7 +482,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -494,7 +494,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-multifile.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-multifile.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -405,7 +405,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -417,7 +417,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -429,7 +429,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -441,7 +441,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -453,7 +453,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -465,7 +465,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -477,7 +477,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-slo-plugin-k8s.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-slo-plugin-k8s.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -30,7 +30,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -42,7 +42,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -54,7 +54,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -66,7 +66,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -78,7 +78,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -90,7 +90,7 @@ spec:
     - expr: |
         (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
         /
-        (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+        ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
       labels:
         global01k1: global01v1
         global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-slo-plugin.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-slo-plugin.yaml.tpl
@@ -10,7 +10,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[5m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[5m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[5m]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -22,7 +22,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[30m])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[30m])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[30m]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -34,7 +34,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1h]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -46,7 +46,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[2h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[2h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[2h]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -58,7 +58,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[6h])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[6h])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[6h]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -70,7 +70,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[1d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[1d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[1d]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1
@@ -82,7 +82,7 @@ groups:
     expr: |
       (sum(rate(http_request_duration_seconds_count{job="myservice",code=~"(5..|429)"}[3d])))
       /
-      (sum(rate(http_request_duration_seconds_count{job="myservice"}[3d])))
+      ((sum(rate(http_request_duration_seconds_count{job="myservice"}[3d]))) > 0)
     labels:
       owner: myteam
       sloth_id: svc01-slo1


### PR DESCRIPTION
Preventing infinite burn rates and issues with BurnRate calculation.

Two root causes of +Inf/-Inf error budget values are addressed:

1. Validation (pkg/common/validation/slo.go): change objective bound from
   > 100 to >= 100, blocking Objective=100 which yields a zero error budget
   and causes division by zero (burn_rate = +Inf, remaining = -Inf).

2. Events SLI template (internal/plugin/slo/core/sli_rules_v1/plugin.go): wrap the denominator with ((...) > 0) so a zero or absent denominator produces an absent result instead of +Inf.  A single +Inf sample in the 5m SLI recording rule would poison sum_over_time for up to 30d, propagating +Inf through slo:period_burn_rate:ratio and flipping to -Inf in slo:period_error_budget_remaining:ratio.

All affected unit and integration golden-file tests are updated.

I think this would fix: https://github.com/slok/sloth/issues/749