### PR TITLE
fix(server): initialize prometheus headers map to avoid nil map panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `server --prometheus-header` no longer panics with "assignment to entry in nil map".
+
 ## [v0.16.0] - 2026-04-04
 
 ### Added

--- a/cmd/sloth/commands/server.go
+++ b/cmd/sloth/commands/server.go
@@ -63,6 +63,7 @@ type serverCommand struct {
 // NewServerCommand returns the UI command.
 func NewServerCommand(app *kingpin.Application) Command {
 	c := &serverCommand{}
+	c.prometheus.headers = map[string]string{}
 	cmd := app.Command("server", "Starts the Sloth web server.")
 	cmd.Flag("app-listen-address", "Application listen address.").Default(":8080").StringVar(&c.appServer.address)
 	cmd.Flag("status-listen-address", "Status (health check, metrics, pprof...) listen address.").Default(":8081").StringVar(&c.statusServer.address)

--- a/cmd/sloth/commands/server_test.go
+++ b/cmd/sloth/commands/server_test.go
@@ -1,0 +1,24 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slok/sloth/cmd/sloth/commands"
+)
+
+// TestServerCommandPrometheusHeaderFlag checks that the `server --prometheus-header`
+// flag can be parsed without panicking. Regression test for the nil map panic
+// ("assignment to entry in nil map") reported when the backing map was not
+// initialized before being used by kingpin's StringMap value.
+func TestServerCommandPrometheusHeaderFlag(t *testing.T) {
+	app := kingpin.New("sloth", "test")
+	commands.NewServerCommand(app)
+
+	cmd, err := app.Parse([]string{"server", "--prometheus-header=Some-Header=Value"})
+	require.NoError(t, err)
+	assert.Equal(t, "server", cmd)
+}


### PR DESCRIPTION
Fixes #819.

`sloth server --prometheus-header='k=v'` panicked with `assignment to entry in nil map` because `serverCommand.prometheus.headers` was passed to `StringMapVar` while still nil. The equivalent `--extra-labels` flag in `generate`/`validate`/`k8scontroller` works because those commands initialize the map (`&generateCommand{extraLabels: map[string]string{}}`); `server` did not.

Initializes the map in `NewServerCommand` and adds a regression test that parses `server --prometheus-header=...` and asserts no panic (fails before the fix, passes after). `go build ./...`, `go vet ./cmd/...` and the new test pass locally.